### PR TITLE
Calico fix : use the right service-cidr

### DIFF
--- a/forked/config.ps1
+++ b/forked/config.ps1
@@ -9,7 +9,7 @@ ipmo $baseDir\libs\calico\calico.psm1
 $env:KUBE_NETWORK = "Calico.*"
 
 # Set to match your Kubernetes service CIDR.
-$env:K8S_SERVICE_CIDR = "<your service cidr>"
+$env:K8S_SERVICE_CIDR = "10.96.0.0/12"
 $env:DNS_NAME_SERVERS = "<your dns server ips>"
 $env:DNS_SEARCH = "svc.cluster.local"
 # Set this to one of the following values:

--- a/sync/shared/kubejoin.ps1
+++ b/sync/shared/kubejoin.ps1
@@ -1,3 +1,3 @@
 $env:path += ";C:\Program Files\containerd"
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
-kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token ttcnkw.7vtvjbj0r2l7zxcw --discovery-token-ca-cert-hash sha256:d8856a1e5474d6fea562f3b8a99b5db806f4e1a5fc110a7841582b9fda632c49 
+kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token 5y178d.8hyknflg5s1kcycg --discovery-token-ca-cert-hash sha256:a774745870de218114f0573a2355da9a6c0fa6d6c70f1ad600f9bc32674be064 

--- a/sync/shared/variables.yaml
+++ b/sync/shared/variables.yaml
@@ -36,4 +36,4 @@ windows_cpus: 4
 
 ###################### CHOOSE YOUR CNI $$$$$$$$$$$$$$$
 cni: "calico"
-#cni: "antrea"
+# cni: "antrea"


### PR DESCRIPTION
im going to just push this as its critical and is a no brainer . 
fix calico service cidrs so that the we dont need to bug sravanth in the middle of the night
to read EVT logs for us :)