### PR TITLE
Using node-ip for windows and controlplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ sync/config
 sync/windows/bin/
 sync/linux/bin/
 sync/shared/config
+sync/shared/kubejoin.ps1
+sync/shared/kubeadm.yaml
 kubernetes
 .vagrant/

--- a/forked/PrepareNode.ps1
+++ b/forked/PrepareNode.ps1
@@ -190,7 +190,7 @@ if ($global:containerRuntime -eq "Docker") {
 }
 
 # TODO Add dynamic node ip here !
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd --node-ip=10.20.30.11"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/sync/shared/kubejoin.ps1
+++ b/sync/shared/kubejoin.ps1
@@ -1,3 +1,0 @@
-$env:path += ";C:\Program Files\containerd"
-[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
-kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token 589d1w.x5or7eq04ih2d8tu --discovery-token-ca-cert-hash sha256:14e9444a5d9c0626c338a1fe2343d196e1abf9a860c4f5d905738a5427bfabf5 


### PR DESCRIPTION
Kubelet was using internal vagrant network, this PR forces the node-ip for both Kubelet processes.

```
vagrant@controlplane:~$ kubectl get nodes -o wide
NAME           STATUS   ROLES                  AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                    KERNEL-VERSION     CONTAINER-RUNTIME
controlplane   Ready    control-plane,master   78m   v1.21.0   10.20.30.10   <none>        Ubuntu 20.04.2 LTS                          5.4.0-80-generic   docker://20.10.5
winw1          Ready    <none>                 69m   v1.21.2   10.20.30.11   <none>        Windows Server 2019 Datacenter Evaluation   10.0.17763.1935    containerd://1.4.4
```