### PR TITLE
Vxlan adapter configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ sync/config
 sync/windows/bin/
 sync/linux/bin/
 sync/shared/config
+sync/shared/kubejoin.ps1
+sync/shared/kubeadm.yaml
 kubernetes
 .vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,7 @@ Vagrant.configure(2) do |config|
           # only run final provisioning step if 'provisioned' is there...
         else
           winw1.vm.provision "shell", path: "forked/2-calico.ps1", privileged: true #, run: "always"
+          winw1.vm.provision "shell", path: "forked/3-calico.ps1", privileged: true #, run: "always"
         end
       else
         if File.file?("cni") then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ settings = YAML.load_file settingsFile
 k8s_linux_registry=settings['k8s_linux_registry']
 k8s_linux_kubelet_deb=settings['k8s_linux_kubelet_deb']
 k8s_linux_apiserver=settings['k8s_linux_apiserver']
+k8s_linux_kubelet_nodeip=settings['k8s_linux_kubelet_nodeip']
 kubernetes_compatibility=settings['kubernetes_compatibility']
 
 overwrite_linux_bins = settings['overwrite_linux_bins']
@@ -17,6 +18,7 @@ linux_ram = settings['linux_ram']
 linux_cpus = settings['linux_cpus']
 windows_ram = settings['windows_ram']
 windows_cpus = settings['windows_cpus']
+windows_node_ip = settings['windows_node_ip']
 cni = settings['cni']
 
 Vagrant.configure(2) do |config|
@@ -31,7 +33,7 @@ Vagrant.configure(2) do |config|
     # controlplane.vm.box = "ubuntu/focal64"
     # better because its available on vmware and virtualbox:
     # controlplane.vm.box = "bento/ubuntu-18.04"
-    controlplane.vm.network :private_network, ip:"10.20.30.10"
+    controlplane.vm.network :private_network, ip:"#{k8s_linux_kubelet_nodeip}"
     controlplane.vm.provider :virtualbox do |vb|
     controlplane.vm.synced_folder "./sync/shared", "/var/sync/shared"
     controlplane.vm.synced_folder "./forked", "/var/sync/forked"
@@ -44,7 +46,7 @@ Vagrant.configure(2) do |config|
     # 1) this seems to break the ability to get to the internet
 
     #controlplane.vm.provision :shell, privileged: true, inline: "sudo ip route add default via 10.20.30.10"
-    controlplane.vm.provision :shell, privileged: false, path: "sync/linux/controlplane.sh", args: "#{overwrite_linux_bins} #{k8s_linux_registry} #{k8s_linux_kubelet_deb} #{k8s_linux_apiserver} "
+    controlplane.vm.provision :shell, privileged: false, path: "sync/linux/controlplane.sh", args: "#{overwrite_linux_bins} #{k8s_linux_registry} #{k8s_linux_kubelet_deb} #{k8s_linux_apiserver} #{k8s_linux_kubelet_nodeip}"
 
     # TODO shoudl we pass KuberneteVersion to calico agent exe? and also service cidr if needed?
     # dont run as priveliged cuz we need the kubeconfig from regular user
@@ -63,7 +65,7 @@ Vagrant.configure(2) do |config|
   config.vm.define :winw1 do |winw1|
     winw1.vm.host_name = "winw1"
     winw1.vm.box = "StefanScherer/windows_2019"  
-    winw1.vm.network :private_network, ip:"10.20.30.11"
+    winw1.vm.network :private_network, ip:"#{windows_node_ip}"
     winw1.vm.synced_folder ".", "/vagrant", disabled:true
     winw1.vm.synced_folder "./sync/shared", "C:/sync/shared"
     winw1.vm.synced_folder "./sync/windows/", "C:/sync/windows/"
@@ -81,7 +83,7 @@ Vagrant.configure(2) do |config|
       winw1.vm.provision "shell", path: "sync/windows/containerd1.ps1", privileged: true #, run: "never"
       winw1.vm.provision :reload
       winw1.vm.provision "shell", path: "sync/windows/containerd2.ps1", privileged: true #, run: "never"
-      winw1.vm.provision "shell", path: "forked/PrepareNode.ps1", privileged: true, args: "-KubernetesVersion #{kubernetes_compatibility} -ContainerRuntime containerD #{overwrite_windows_bins }" #, run: "never"
+      winw1.vm.provision "shell", path: "forked/PrepareNode.ps1", privileged: true, args: "-KubernetesVersion #{kubernetes_compatibility} -WindowsNodeIP #{windows_node_ip} -ContainerRuntime containerD #{overwrite_windows_bins} " #, run: "never"
       winw1.vm.provision "shell", path: "sync/shared/kubejoin.ps1", privileged: true #, run: "never"
       winw1.vm.provision "shell", path: "sync/windows/ssh.ps1", privileged: true #, run: "never"
     else

--- a/forked/1-calico.ps1
+++ b/forked/1-calico.ps1
@@ -27,6 +27,7 @@ if (-not (Test-Path -Path ./install-calico.ps1 -PathType Leaf)) {
     
     cp C:/forked/install-calico.ps1 ./
     cp C:/forked/calico.psm1 ./libs/calico/
+    cp C:/forked/node-service.ps1 ./node/node-service.ps1
     cp C:/forked/config.ps1 ./
     Write-Output "................ DONE Copying forked calico files"
 

--- a/forked/3-calico.ps1
+++ b/forked/3-calico.ps1
@@ -1,0 +1,8 @@
+Write-Output "Starting Kube-proxy and Kubelet..."
+
+C:\CalicoWindows\kubernetes\install-kube-services.ps1
+
+Write-Output "Starting Kube-proxy and Kubelet..."
+
+Start-Service -Name kubelet
+Start-Service -Name kube-proxy

--- a/forked/PrepareNode.ps1
+++ b/forked/PrepareNode.ps1
@@ -190,7 +190,7 @@ if ($global:containerRuntime -eq "Docker") {
 }
 
 # TODO Add dynamic node ip here !
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd --node-ip=10.20.30.11"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/forked/PrepareNode.ps1
+++ b/forked/PrepareNode.ps1
@@ -47,12 +47,14 @@ Param(
     [parameter(HelpMessage="Allows to overwrite bins with self-built ones")]
     [switch] $OverwriteBins,
 
+    [parameter(HelpMessage="Kubelet Node IP")]
+    [string] $WindowsNodeIP = "10.20.30.11",
+
     [parameter(HelpMessage="kubelet source build path")]
     [string] $SelfBuiltKubeletSource = "C:/sync/windows/bin/kubelet.exe",
 
     [parameter(HelpMessage="kube-proxy source build path")]
-    [string] $SelfBuiltKubeProxySource = "C:/sync/windows/bin/kube-proxy.exe"
-
+    [string] $SelfBuiltKubeProxySource = "C:/sync/windows/bin/kube-proxy.exe" 
 )
 $ErrorActionPreference = 'Stop'
 Write-Output "Overwriting bins is set to '$OverwriteBins'"
@@ -190,7 +192,7 @@ if ($global:containerRuntime -eq "Docker") {
 }
 
 # TODO Add dynamic node ip here !
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd --node-ip=10.20.30.11"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --container-runtime=remote --container-runtime-endpoint=npipe:////.//pipe//containerd-containerd --node-ip=$WindowsNodeIP"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/forked/config.ps1
+++ b/forked/config.ps1
@@ -92,6 +92,8 @@ $env:CNI_IPAM_TYPE = "calico-ipam"
 $env:VXLAN_VNI = "4096"
 # Prefix used when generating MAC addresses for virtual NICs.
 $env:VXLAN_MAC_PREFIX = "0E-2A"
+# Network Adapter used on VXLAN, leave blank for primary NIC.
+$env:VXLAN_ADAPTER = "Ethernet 2"
 
 
 ## Node configuration.

--- a/forked/node-service.ps1
+++ b/forked/node-service.ps1
@@ -1,0 +1,161 @@
+# Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is run from the main Calico folder.
+. .\config.ps1
+
+ipmo .\libs\calico\calico.psm1
+ipmo .\libs\hns\hns.psm1
+
+$lastBootTime = Get-LastBootTime
+$Stored = Get-StoredLastBootTime
+Write-Host "StoredLastBootTime $Stored, CurrentLastBootTime $lastBootTime"
+
+$timeout = $env:STARTUP_VALID_IP_TIMEOUT
+$vxlanAdapter = $env:VXLAN_ADAPTER
+
+# Autoconfigure the IPAM block mode.
+if ($env:CNI_IPAM_TYPE -EQ "host-local") {
+    $env:USE_POD_CIDR = "true"
+} else {
+    $env:USE_POD_CIDR = "false"
+}
+
+$platform = Get-PlatformType
+
+if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_BACKEND -EQ "vxlan")
+{
+    Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
+
+    # Check if the node has been rebooted.  If so, the HNS networks will be in unknown state so we need to
+    # clean them up and recreate them.
+    $prevLastBootTime = Get-StoredLastBootTime
+    if ($prevLastBootTime -NE $lastBootTime)
+    {
+        if ((Get-HNSNetwork | ? Type -NE nat))
+        {
+            Write-Host "First time Calico has run since boot up, cleaning out any old network state."
+            Get-HNSNetwork | ? Type -NE nat | Remove-HNSNetwork
+            do
+            {
+                Write-Host "Waiting for network deletion to complete."
+                Start-Sleep 1
+            } while ((Get-HNSNetwork | ? Type -NE nat))
+        }
+
+        # After deletion of all hns networks, wait for an interface to have an IP that is not a 169.254.0.0/16 (or 127.0.0.0/8) address,
+        # before creation of External network.
+        $isValidIP = $false
+        $IPRegEx1='(^127\.0\.0\.)'
+        $IPRegEx2='(^169\.254\.)'
+        while(!($isValidIP) -AND ($timeout -gt 0))
+        {
+            $IPAddress = (Get-NetIPAddress -AddressFamily IPv4).IPAddress
+            Write-Host "`nTimeout Remaining: $timeout sec"
+            Write-Host "List of IP Address before initialising Calico: $IPAddress"
+            Foreach ($ip in $IPAddress)
+            {
+                if (($ip -NotMatch $IPRegEx1) -AND ($ip -NotMatch $IPRegEx2))
+                {
+                    $isValidIP = $true
+                    Write-Host "`nFound valid IP: $ip"
+                    break
+                }
+            }
+            if (!($isValidIP))
+            {
+                Start-Sleep -s 5
+                $timeout = $timeout - 5
+            }
+        }
+    }
+
+    # Create a bridge to trigger a vSwitch creation. Do this only once
+    Write-Host "`nStart creating vSwitch. Note: Connection may get lost for RDP, please reconnect...`n"
+    while (!(Get-HnsNetwork | ? Name -EQ "External"))
+    {
+        if ($env:CALICO_NETWORKING_BACKEND -EQ "vxlan") {
+            # FIXME Firewall rule port?
+            New-NetFirewallRule -Name OverlayTraffic4789UDP -Description "Overlay network traffic UDP" -Action Allow -LocalPort 4789 -Enabled True -DisplayName "Overlay Traffic 4789 UDP" -Protocol UDP -ErrorAction SilentlyContinue
+            $result = New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }) -AdapterName $vxlanAdapter -Verbose
+        }
+        else
+        {
+            $result = New-HNSNetwork -Type L2Bridge -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -Verbose
+        }
+        if ($result.Error -OR (!$result.Success)) {
+            Write-Host "Failed to create network, retrying..."
+            Start-Sleep 1
+        } else {
+            break
+        }
+    }
+
+    # Wait for the management IP to show up and then give an extra grace period for
+    # the networking stack to settle down.
+    $mgmtIP = Wait-ForManagementIP "External"
+    Write-Host "Management IP detected on vSwitch: $mgmtIP."
+    Start-Sleep 10
+
+    if (($platform -EQ "ec2") -or ($platform -EQ "gce")) {
+        Set-MetaDataServerRoute -mgmtIP $mgmtIP
+    }
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp") {
+        Write-Host "Restarting BGP service to pick up any interface renumbering..."
+        Restart-Service RemoteAccess
+    }
+}
+
+$env:CALICO_NODENAME_FILE = ".\nodename"
+
+# We use this setting as a trigger for the other scripts to proceed.
+Set-StoredLastBootTime $lastBootTime
+$Stored = Get-StoredLastBootTime
+Write-Host "Stored new lastBootTime $Stored"
+
+# Run the startup script whenever kubelet (re)starts. This makes sure that we refresh our Node annotations if
+# kubelet recreates the Node resource.
+$kubeletPid = -1
+while ($True)
+{
+    try
+    {
+        # Run calico-node.exe if kubelet starts/restarts
+        $currentKubeletPid = (Get-Process -Name kubelet -ErrorAction Stop).id
+        if ($currentKubeletPid -NE $kubeletPid)
+        {
+            Write-Host "Kubelet has (re)started, (re)initialising the node..."
+            $kubeletPid = $currentKubeletPid
+            while ($true)
+            {
+                .\calico-node.exe -startup
+                if ($LastExitCode -EQ 0)
+                {
+                    Write-Host "Calico node initialisation succeeded; monitoring kubelet for restarts..."
+                    break
+                }
+
+                Write-Host "Calico node initialisation failed, will retry..."
+                Start-Sleep 1
+            }
+        }
+    }
+    catch
+    {
+        Write-Host "Kubelet not running, waiting for Kubelet to start..."
+        $kubeletPid = -1
+    }
+    Start-Sleep 10
+}

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -17,11 +17,11 @@ set -e
 
 # TODO Add these as command line options
 
-echo "ARGS: $1 $2 $3 $4"
-if [[ "$1" == "" || "$2" == "" || "$3" == "" || "$4" == "" ]] ; then
+echo "ARGS: $1 $2 $3 $4 $5"
+if [[ "$1" == "" || "$2" == "" || "$3" == "" || "$4" == "" || "$5" == "" ]] ; then
   cat << EOF
     Missing args.
-    You need to send overwrite_linux_bins, k8s_linux_registry, k8s_linux_kubelet_deb, k8s_linux_apiserver, i.e. something like...
+    You need to send overwrite_linux_bins, k8s_linux_registry, k8s_linux_kubelet_deb, k8s_linux_apiserver, k8s_kubelet_nodeip i.e. something like...
     ./controlplane.sh false gcr.io/k8s-staging-ci-images 1.21.0 v1.22.0-alpha.3.31+a3abd06ad53b2f"}
     Normally these are in your variables.yml, and piped in by Vagrant.
     So, check that you didn't break the Vagrantfile :)
@@ -35,6 +35,7 @@ overwrite_linux_bins=${1}
 k8s_linux_registry=${2}
 k8s_linux_kubelet_deb=${3}
 k8s_linux_apiserver=${4}
+k8s_kubelet_node_ip=${5}
 
 echo "Using $kubernetes_version as the Kubernetes version"
 echo "Overwriting bins is set to '$overwrite_bins'"
@@ -131,10 +132,10 @@ cat << EOF > /var/sync/shared/kubeadm.yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 localAPIEndpoint:
-  advertiseAddress: 10.20.30.10
+  advertiseAddress: $k8s_kubelet_node_ip
 nodeRegistration:
   kubeletExtraArgs:
-    node-ip: 10.20.30.10
+    node-ip: $k8s_kubelet_node_ip
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration

--- a/sync/shared/kubejoin.ps1
+++ b/sync/shared/kubejoin.ps1
@@ -1,3 +1,0 @@
-$env:path += ";C:\Program Files\containerd"
-[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
-kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token 589d1w.x5or7eq04ih2d8tu --discovery-token-ca-cert-hash sha256:14e9444a5d9c0626c338a1fe2343d196e1abf9a860c4f5d905738a5427bfabf5 

--- a/sync/shared/variables.yaml
+++ b/sync/shared/variables.yaml
@@ -6,6 +6,7 @@ overwrite_windows_bins: "false"
 
 kubelet_path:  "./sync/windows/bin/kubelet.exe"
 kubeproxy_path:  "./sync/windows/bin/kube-proxy.exe"
+windows_node_ip: "10.20.30.11"
 
 # LINUX KUBELET VERSION
 # LINUX KUBEADM VERSION
@@ -14,6 +15,7 @@ kubeproxy_path:  "./sync/windows/bin/kube-proxy.exe"
 k8s_linux_registry: "gcr.io/k8s-staging-ci-images"
 k8s_linux_kubelet_deb:  "1.21.0"
 k8s_linux_apiserver: "ci/v1.22.0-alpha.3.31+a3abd06ad53b2f"
+k8s_linux_kubelet_nodeip: "10.20.30.10"
 
 # WINDOWS KUBELET VERSION
 # This is the -KubernetesVersion sent to


### PR DESCRIPTION
Avoid to use the primary NIC (Vagrant internal interface) as the vxlan interface.

Allows to choose via parameter and forcing `Ethernet 2` - 10.20.30.0 network