### PR TITLE
added cgroup driver flag

### DIFF
--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -136,6 +136,7 @@ localAPIEndpoint:
 nodeRegistration:
   kubeletExtraArgs:
     node-ip: $k8s_kubelet_node_ip
+    cgroup-driver: cgroupfs
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration


### PR DESCRIPTION
As part of the 1.22.0 release the default group driver has changed from cgroupfs to systemd, we now need to specify this in order to have a 1.22.0 kubelet running on the control plane