### PR TITLE
Downloading Calico requirements on box

### DIFF
--- a/experiments/image-builder/image-builder.sh
+++ b/experiments/image-builder/image-builder.sh
@@ -42,10 +42,15 @@ function clean {
 
 function build_configuration {
  jq --null-input \
-    --arg iso_url "${VBOX_WINDOWS_ISO}"             \
-    --arg runtime "${VBOX_WINDOWS_RUNTIME}"         \
-    --arg custom_role_names "${VBOX_WINDOWS_ROLES}" \
-    '{"os_iso_url": $iso_url, "runtime": $runtime, "ansible_extra_vars": "custom_role=true", "custom_role_names": $custom_role_names}' > ${tmpfile}
+    --arg iso_url "${VBOX_WINDOWS_ISO}"                      \
+    --arg runtime "${VBOX_WINDOWS_RUNTIME}"                  \
+    --arg custom_role_names "${VBOX_WINDOWS_ROLES}"          \
+    '{
+        "os_iso_url": $iso_url,
+        "runtime": $runtime,
+        "ansible_extra_vars": "custom_role=true",
+        "custom_role_names": $custom_role_names,
+    }' > ${tmpfile}
 }
 
 function copy_overlay_files {

--- a/experiments/image-builder/overlays/ansible/roles/utilities/tasks/main.yml
+++ b/experiments/image-builder/overlays/ansible/roles/utilities/tasks/main.yml
@@ -1,9 +1,25 @@
 - name: Enable ssh login with password
   win_shell: Set-Content -Path "$env:ProgramData\ssh\sshd_config" -Value "PasswordAuthentication yes`nPubkeyAuthentication yes"
 
-  # CHOCO PACKAGES
-  # for more packages: https://community.chocolatey.org/packages
-  # on how to use ansible's choco plugin: https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_module.html#examples
+## CNI binary installation
+
+- name: Download Calico tooling
+  win_shell: |
+    Write-Output "Calico Running Pre-Install"
+
+    Install-WindowsFeature RemoteAccess
+    Install-WindowsFeature RSAT-RemoteAccess-PowerShell
+    Install-WindowsFeature Routing
+    Install-RemoteAccess -VpnType RoutingOnly
+    Start-Service RemoteAccess
+
+    Write-Output "Installing Calico"
+    Invoke-WebRequest https://docs.projectcalico.org/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+
+# CHOCO PACKAGES
+# for more packages: https://community.chocolatey.org/packages
+# on how to use ansible's choco plugin: https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_module.html#examples
+
 - name: Ensure Chocolatey itself is installed and use internal repo as source
   win_chocolatey:
     name: chocolatey


### PR DESCRIPTION
Installing the `first` step of Calico, ISN'T possible to install all steps of calico/antrea without a joined cluster, for this reason the only steps here are installing the required services and getting the box ready to final calico installation  