### PR TITLE
Make vagrant-vbguest a pre-requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ viable alternative to Linux thanks to the recent introduction of Windows HostPro
 ## Prerequisites
 
 - Vagrant
-- Vagrant reload, winrm and winrm-elevated plugins
+- Vagrant vagrant-vbguest, reload, winrm and winrm-elevated plugins
 - some Vagrant provider (we only have VirtualBox automated here, but these recipes have been used with others, like HyperV and Fusion).
 
 # Lets run it!

--- a/makefile
+++ b/makefile
@@ -34,9 +34,6 @@ all: 0-fetch-k8s 1-build-binaries 2-vagrant-up 3-smoke-test 4-e2e-test
 	echo "cleaning up semaphores..."
 	rm -f up joined cni
 
-	echo "installing vagrant vbguest plugin..."
-	vagrant plugin install vagrant-vbguest
-
 	echo "######################################"
 	echo "Retry vagrant up if the first time the windows node failed"
 	echo "Starting the control plane"


### PR DESCRIPTION
This slightly decreases the running `make 2`