### PR TITLE
Allow working with latest k8s components

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ build_binaries () {
 		# use the kubernetes/build/run script to build specific targets...
 		./build/run.sh make kubelet KUBE_BUILD_PLATFORMS=windows/amd64
 		./build/run.sh make kube-proxy KUBE_BUILD_PLATFORMS=windows/amd64
+		./build/run.sh make kubeadm KUBE_BUILD_PLATFORMS=windows/amd64
 
 		./build/run.sh make kubelet KUBE_BUILD_PLATFORMS=linux/amd64
 		./build/run.sh make kubectl KUBE_BUILD_PLATFORMS=linux/amd64
@@ -45,6 +46,8 @@ build_binaries () {
 	mkdir -p $startDir/sync/windows/bin
 	cp -f ./_output/dockerized/bin/windows/amd64/kubelet.exe $startDir/sync/windows/bin
 	cp -f ./_output/dockerized/bin/windows/amd64/kube-proxy.exe $startDir/sync/windows/bin
+	cp -f ./_output/dockerized/bin/windows/amd64/kubeadm.exe $startDir/sync/windows/bin
+
 	#linux
 	mkdir -p $startDir/sync/linux/bin
 	cp -f ./_output/dockerized/bin/linux/amd64/kubelet $startDir/sync/linux/bin

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -122,7 +122,7 @@ sudo crictl config --set runtime-endpoint=unix:///run/containerd/containerd.sock
 # sudo kubeadm init --apiserver-advertise-address=10.20.30.10 --pod-network-cidr=10.244.0.0/16 --image-repository="k8s.gcr.io" --kubernetes-version="v1.22.0-alpha.3.31+a3abd06ad53b2f"
 
 cat << EOF > /var/sync/shared/kubeadm.yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: $k8s_kubelet_node_ip
@@ -131,7 +131,7 @@ nodeRegistration:
     node-ip: $k8s_kubelet_node_ip
     cgroup-driver: cgroupfs
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 kubernetesVersion: $k8s_linux_apiserver
 networking:
@@ -154,6 +154,8 @@ cp $HOME/.kube/config /var/sync/shared/config
 rm -f /var/sync/shared/kubejoin.ps1
 
 cat << EOF > /var/sync/shared/kubejoin.ps1
+cp C:\Users\vagrant\crictl.exe "C:\Program Files\containerd"
+cp C:\sync\windows\bin\* c:\k
 \$env:path += ";C:\Program Files\containerd"
 [Environment]::SetEnvironmentVariable("Path", \$env:Path, [System.EnvironmentVariableTarget]::Machine)
 EOF

--- a/sync/shared/variables.yaml
+++ b/sync/shared/variables.yaml
@@ -1,5 +1,5 @@
-# 286709... v1.21.2-rc.0 has the kube-proxy userspace fix...
-kubernetes_sha: "286709307da5adb62e78d989b7ed846355d5c88e"
+# v1.23.1
+kubernetes_sha: "86ec240af8cbd1b60bcc4c03c20da9b98005b92e"
 # this is the compatbility version, determining args we send to antrea and so on
 kubernetes_compatibility:  "1.21.2"
 overwrite_windows_bins: "false"
@@ -14,7 +14,7 @@ windows_node_ip: "10.20.30.11"
 # from https://apt.kubernetes.io/
 k8s_linux_registry: "gcr.io/k8s-staging-ci-images"
 k8s_linux_kubelet_deb:  "1.21.0"
-k8s_linux_apiserver: "ci/v1.22.0-alpha.3.31+a3abd06ad53b2f"
+k8s_linux_apiserver: "ci/latest"
 k8s_linux_kubelet_nodeip: "10.20.30.10"
 
 # WINDOWS KUBELET VERSION


### PR DESCRIPTION
- Copy Windows kubeadm to the sync directory
- Update the image tags
- Move to using kubeadm.k8s.io/v1beta3
- Copy crictl.exe to C:\Program Files\containerd to stop kubeadm from
  complaining about missing crictl
- Overwrite C:\k\ binaries with the latest binaries from  C:\sync\windows\bin
- Update k8s_linux_apiserver in variables.yaml to point to `ci/latest`