### PR TITLE
vagrant: clean all vms

### DIFF
--- a/makefile
+++ b/makefile
@@ -58,6 +58,9 @@ all: 0-fetch-k8s 1-build-binaries 2-vagrant-up 3-smoke-test 4-e2e-test
 4-e2e-test:
 	vagrant ssh controlplane -c "cd /var/sync/linux && chmod +x ./e2e.sh && ./e2e.sh"
 
+vagrant-clean-all-vms:
+	@./tools/vagrant/clean_all_vagrand_vms.sh
+
 clean:
 	rm -rf sync/linux/bin/
 	rm -rf sync/windows/bin/

--- a/tools/vagrant/clean_all_vagrand_vms.sh
+++ b/tools/vagrant/clean_all_vagrand_vms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IDsVMs=($(VBoxManage list vms | awk -F '[{}]' '{print $2}'))
+
+for idvm in "${IDsVMs[@]}";
+do 
+	echo "Powering off VM: ${idvm}..."
+	VBoxManage controlvm "${idvm}" poweroff
+
+	echo "Deleting VM ${idvm}..."
+	VBoxManage unregistervm ${idvm} --delete
+done


### PR DESCRIPTION
If there are multiple instances of sig-windows-dev-tools running
(in different directories) it might bring network conflicts.
This script clean all vms for a fresh start. The vagrant destroy --force
cleans the environment in the directory not all vms.

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>