### PR TITLE
controlplane: copy crictl.exe to containerd dir

### DIFF
--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -154,6 +154,10 @@ cp $HOME/.kube/config /var/sync/shared/config
 rm -f /var/sync/shared/kubejoin.ps1
 
 cat << EOF > /var/sync/shared/kubejoin.ps1
+if(!(Test-Path ("C:\Program Files\containerd\crictl.exe"))) {
+    mv "C:\Users\vagrant\crictl.exe" "C:\Program Files\containerd\"
+}
+
 \$env:path += ";C:\Program Files\containerd"
 [Environment]::SetEnvironmentVariable("Path", \$env:Path, [System.EnvironmentVariableTarget]::Machine)
 EOF


### PR DESCRIPTION
During the build there is an error regarding missing
crictl.exe. This patch fix it.

Signed-off-by: Aravindh Puthiyaparambil <aravindh@redhat.com>
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>