### PR TITLE
sync: use the latest CI image for API Server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,13 @@ settingsFile = ENV["VAGRANT_VARIABLES"] || 'sync/shared/variables.yaml'
 settings = YAML.load_file settingsFile
 k8s_linux_registry=settings['k8s_linux_registry']
 k8s_linux_kubelet_deb=settings['k8s_linux_kubelet_deb']
-k8s_linux_apiserver=settings['k8s_linux_apiserver']
+
+if settings['k8s_linux_apiserver'] == "" then
+    k8s_linux_apiserver="ci/" + `curl https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt | tr -d '\n'`
+else
+    k8s_linux_apiserver=settings['k8s_linux_apiserver']
+end
+
 k8s_linux_kubelet_nodeip=settings['k8s_linux_kubelet_nodeip']
 kubernetes_compatibility=settings['kubernetes_compatibility']
 

--- a/sync/shared/variables.yaml
+++ b/sync/shared/variables.yaml
@@ -14,7 +14,10 @@ windows_node_ip: "10.20.30.11"
 # from https://apt.kubernetes.io/
 k8s_linux_registry: "gcr.io/k8s-staging-ci-images"
 k8s_linux_kubelet_deb:  "1.21.0"
-k8s_linux_apiserver: "ci/v1.22.0-alpha.3.31+a3abd06ad53b2f"
+
+# If no version provided for k8s_linux_apiserver it will take
+# the latest ci image version. Example: ci/v1.22.6-rc.0.55+487eef699dc8ad
+k8s_linux_apiserver: ""
 k8s_linux_kubelet_nodeip: "10.20.30.10"
 
 # WINDOWS KUBELET VERSION


### PR DESCRIPTION
Instead of static version, let's explore the latest CI image version available.

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>