### PR TITLE
Removing kubectl from antrea install

### DIFF
--- a/sync/windows/0-antrea.ps1
+++ b/sync/windows/0-antrea.ps1
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
+Set-PSDebug -Trace 2
+
 # Force Kubernetes folder
 mkdir -Force C:/k/
 
@@ -40,7 +42,6 @@ $antreaInstallationFiles = @{
       "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Helper.psm1" = "C:/k/antrea/Helper.psm1"
       "https://github.com/antrea-io/antrea/releases/download/v1.4.0/antrea-agent-windows-x86_64.exe" = "C:/k/antrea/bin/antrea-agent.exe"
       "https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-windows-amd64-v0.9.1.tgz" = "C:/k/antrea/bin/cni-plugins-windows-amd64-v0.9.1.tgz"
-      "https://dl.k8s.io/release/v1.21.0/bin/windows/amd64/kubectl.exe" = "C:/k/kubectl.exe"
       "https://gist.githubusercontent.com/knabben/5dec7c059916d3b487aeb2efd3a689b6/raw/5ae62d1bf8fddac44f81ba3cc532cce685ef8995/antrea.yaml" = "C:/k/antrea/etc/antrea-agent.conf"
       "https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe" = "C:/ssl.exe"
       # this is on jay's bucket because its otherwise a flakey download from https://www.microsoft.com/en-us/download/details.aspx?id=48145
@@ -73,16 +74,13 @@ foreach ($theURL in $antreaInstallationFiles.keys) {
 
 
 Write-Output("Now trying to execute VCD.exe")
-
 C:/vcd.exe /quiet /norestart
 
-
 Write-Output("Now trying to execute SSL.exe")
-
 C:/ssl.exe /silent /verysilent /sp- /suppressmsgboxes
-
-Start-Sleep -s 30
 
 # Signing binaries
 Bcdedit.exe -set TESTSIGNING ON
+
+Start-Sleep -s 50
 Restart-Computer


### PR DESCRIPTION
- Increasing the sleep time for the background installs
- Adding tracing, if this happens again (component download failure) we can have more debug info.

Getting the error mentioned here on Doug's comment:
https://github.com/kubernetes-sigs/sig-windows-dev-tools/pull/165#issuecomment-1016059367

/cc @dougsland 