### PR TITLE
controlplane: add alias, krew plugins and kubetail

### DIFF
--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -85,6 +85,20 @@ do
   fi
 done
 
+# kubetail
+echo "Installing kubetail..."
+sudo /var/sync/linux/tools/controlplane/kubetail/install
+
+# Installing krew
+echo "Installing krew..."
+/var/sync/linux/tools/controlplane/krew/install
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+
+echo "Installing krew plugins..."
+kubectl krew install iexec
+kubectl krew install view-secret
+kubectl krew install ctx
+
 # Configuring and starting containerd
 sudo mkdir -p /etc/containerd
 containerd config default | sudo tee /etc/containerd/config.toml

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -70,7 +70,8 @@ sudo sysctl --system
 # Install containerd and Kubernetes binaries, using latest available, and
 # overwritting the binaries later.
 sudo apt-get install -y containerd kubelet kubeadm kubectl
-
+echo "alias k=kubectl" >> ~/.bashrc
+source ~/.bashrc
 sudo apt-mark hold kubelet kubeadm kubectl
 
 ## Test if binaries folder exists

--- a/sync/linux/tools/controlplane/krew/install
+++ b/sync/linux/tools/controlplane/krew/install
@@ -1,0 +1,28 @@
+#!/bin/bash
+: '
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+echo "export PATH=\"${KREW_ROOT:-$HOME/.krew}/bin:$PATH\"" >> ~/.bashrc
+exit $?

--- a/sync/linux/tools/controlplane/kubetail/install
+++ b/sync/linux/tools/controlplane/kubetail/install
@@ -1,0 +1,20 @@
+#!/bin/bash
+: '
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'
+
+curl -sS https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail -o /usr/bin/kubetail
+chmod +x /usr/bin/kubetail
+exit $?


### PR DESCRIPTION
The sig-windows-dev-tools distro is very helpful for developers, let's add additional tools to make life even easier.
 <pre>   
This patch adds:
            - kubectl krew
            - krew plugin iexec
            - krew plugin ctx
            - krew plugin view-secret
            - kubetail
            - alias k for kubectl
 </pre>
GitHub-Issue: https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/166
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>