### PR TITLE
make: do not show commands

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.SILENT: clean
+
 path ?= kubernetes
 
 all: 0-fetch-k8s 1-build-binaries 2-vagrant-up 3-smoke-test 4-e2e-test
@@ -23,40 +25,39 @@ all: 0-fetch-k8s 1-build-binaries 2-vagrant-up 3-smoke-test 4-e2e-test
 4: 4-e2e-test
 
 0-fetch-k8s: clean
-	chmod +x fetch.sh
-	./fetch.sh
+	@chmod +x fetch.sh
+	@./fetch.sh
 
 1-build-binaries:
-	chmod +x build.sh
-	./build.sh $(path)
+	@chmod +x build.sh
+	@./build.sh $(path)
 
 2-vagrant-up:
-	@echo "cleaning up semaphores..."
 	@rm -rf .lock/
 	@mkdir -p .lock/
 
-	echo "######################################"
-	echo "Retry vagrant up if the first time the windows node failed"
-	echo "Starting the control plane"
-	echo "######################################"
-	vagrant up controlplane
+	@echo "######################################"
+	@echo "Retry vagrant up if the first time the windows node failed"
+	@echo "Starting the control plane"
+	@echo "######################################"
+	@vagrant up controlplane
 	
-	echo "*********** vagrant up first run done ~~~~ ENTERING WINDOWS BRINGUP LOOP ***"
-	until `vagrant status | grep winw1 | grep -q "running"` ; do vagrant up winw1 || echo failed_win_up ; done
-	until `vagrant ssh controlplane -c "kubectl get nodes" | grep -q winw1` ; do vagrant provision winw1 || echo failed_win_join; done
+	@echo "*********** vagrant up first run done ~~~~ ENTERING WINDOWS BRINGUP LOOP ***"
+	@until `vagrant status | grep winw1 | grep -q "running"` ; do vagrant up winw1 || echo failed_win_up ; done
+	@until `vagrant ssh controlplane -c "kubectl get nodes" | grep -q winw1` ; do vagrant provision winw1 || echo failed_win_join; done
 	@touch .lock/joined
-	vagrant provision winw1
+	@vagrant provision winw1
 	@touch .lock/cni
 
 3-smoke-test:
-	vagrant ssh controlplane -c "kubectl apply -f /var/sync/linux/smoke-test.yaml"
-	vagrant ssh controlplane -c "kubectl scale deployment whoami-windows --replicas 0"
-	vagrant ssh controlplane -c "kubectl scale deployment whoami-windows --replicas 3"
-	vagrant ssh controlplane -c "kubectl wait --for=condition=Ready=true pod -l 'app=whoami-windows' --timeout=600s"
-	vagrant ssh controlplane -c "kubectl exec -it netshoot -- curl http://whoami-windows:80/"
+	@vagrant ssh controlplane -c "kubectl apply -f /var/sync/linux/smoke-test.yaml"
+	@vagrant ssh controlplane -c "kubectl scale deployment whoami-windows --replicas 0"
+	@vagrant ssh controlplane -c "kubectl scale deployment whoami-windows --replicas 3"
+	@vagrant ssh controlplane -c "kubectl wait --for=condition=Ready=true pod -l 'app=whoami-windows' --timeout=600s"
+	@vagrant ssh controlplane -c "kubectl exec -it netshoot -- curl http://whoami-windows:80/"
 
 4-e2e-test:
-	vagrant ssh controlplane -c "cd /var/sync/linux && chmod +x ./e2e.sh && ./e2e.sh"
+	@vagrant ssh controlplane -c "cd /var/sync/linux && chmod +x ./e2e.sh && ./e2e.sh"
 
 clean:
 	vagrant destroy --force


### PR DESCRIPTION
- No need to print commands or "echos" in the build.
- Added the macro .SILENT=clean for make clean

Github-Issue: https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/154
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>