### PR TITLE
calico: add missing rbac

### DIFF
--- a/forked/calico.yaml
+++ b/forked/calico.yaml
@@ -3369,6 +3369,14 @@ rules:
       - list
       # Used to discover Typhas.
       - get
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch
+      - list
   # Pod CIDR auto-detection on kubeadm needs access to config maps.
   - apiGroups: [""]
     resources:

--- a/sync/linux/calico-0.sh
+++ b/sync/linux/calico-0.sh
@@ -6,7 +6,6 @@ KUBECONFIG=/home/vagrant/.kube/config
 
 kubectl create -f /var/sync/forked/calico.yaml
 kubectl taint nodes --all node-role.kubernetes.io/master-
-kubectl create clusterrolebinding calico-node --clusterrole=calico-node --serviceaccount=kube-system:calico-node
 
 echo "waiting 20s for calico pods..."
 sleep 20


### PR DESCRIPTION
Github-Issue: https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/179
See-Also: https://github.com/projectcalico/calico/pull/4769
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>