### PR TITLE
Clean up building from source

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,8 +14,6 @@
 
 .SILENT: clean
 
-path ?= kubernetes
-
 all: 0-fetch-k8s 1-build-binaries 2-vagrant-up 3-smoke-test 4-e2e-test
 
 0: 0-fetch-k8s


### PR DESCRIPTION
The build from source option is typically used when developing code which is then deployed to the VMs. Given that it doesn't make sense to not build just because the `_output` directory is present. Also when building from source there is no reason to compute `KUBERNETES_VERSION`.

Stop setting `path` by default in the `makefile` as that needs to be passed explicitly by the user.