### PR TITLE
Moving file download to calico installation

### DIFF
--- a/experiments/image-builder/overlays/ansible/roles/utilities/tasks/main.yml
+++ b/experiments/image-builder/overlays/ansible/roles/utilities/tasks/main.yml
@@ -1,14 +1,7 @@
 - name: Enable ssh login with password
   win_shell: Set-Content -Path "$env:ProgramData\ssh\sshd_config" -Value "PasswordAuthentication yes`nPubkeyAuthentication yes"
 
-## Calico CNI binary installation
-
-- name: Download Calico install
-  win_get_url:
-    url: "https://docs.projectcalico.org/scripts/install-calico-windows.ps1"
-    dest: 'c:\install-calico-windows.ps1'
-  retries: 5
-  delay: 3
+## Install Kube-Proxy 
 
 - name: Download Kubernetes kube-proxy
   win_get_url:

--- a/sync/windows/0-calico.ps1
+++ b/sync/windows/0-calico.ps1
@@ -23,9 +23,12 @@ New-Item -ItemType HardLink -Target "C:\etc\kubernetes\kubelet.conf" -Path "C:\k
 ## ------------------------------------------
 Write-Output "Downloading Calico Artifacts"
 ## ------------------------------------------
+
+Invoke-WebRequest https://projectcalico.docs.tigera.io/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
 C:\install-calico-windows.ps1 -DownloadOnly yes
 
 ## ------------------------------------------
 Write-Output "Print installed files"
 ## ------------------------------------------
+
 ls C:\CalicoWindows


### PR DESCRIPTION
We should not download the Calico installation in the image builder phase.
Moving the file download to sync phase instead