### PR TITLE
Include vagrant-vbguest in the readme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For the happy path, just:
 0) Start Docker so that you can build K8s from source as needed.
 1) Install Vagrant, and then vagrant-reload
 ```
-vagrant plugin install vagrant-reload winrm winrm-elevated
+vagrant plugin install vagrant-reload winrm winrm-elevated vagrant-vbguest
 ```
 2) Modify CPU/memory in the variables.yml file. We recommend four cores 8G+ for your Windows node if you can spare it, and two cores 8G for your Linux node as well. 
  


### PR DESCRIPTION
Although the `vagrant-vbguest` Vagrant plugin is listed as a preqrequisite on the readme page, the command given doesn't include it. If one tries to setup the 2-node cluster by copying/pasting instructions, the mapped folders on the Windows node won't work as expected (they exist as symlinks, but accessing their content will fail)