### PR TITLE
Fix Windows 1.4.0 antrea manifests

### DIFF
--- a/sync/windows/0-antrea.ps1
+++ b/sync/windows/0-antrea.ps1
@@ -34,17 +34,19 @@ mkdir -Force C:/k/antrea/ # scripts
 mkdir -Force C:/k/antrea/bin/ #executables
 mkdir -Force C:/k/antrea/etc/ # for antrea-agent.conf
 
-# Downloading from vcredist_x64.exe from microsoft.com is flaking inside the script, if this happens 
-# need to do it manually.
 $antreaInstallationFiles = @{
       "https://gist.githubusercontent.com/knabben/f478afc647152bf5c9702411296c604d/raw/fb093e42624411ba2e6933837d3664be34e09320/antrea-cni.conflist" = "C:/etc/cni/net.d/10-antrea.conflist"
       "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Install-OVS.ps1" =  "C:/k/antrea/Install-OVS.ps1"
-      "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Helper.psm1" = "C:/k/antrea/Helper.psm1"
+      # Antrea 1.4.0 install scripts
+      "https://raw.githubusercontent.com/antrea-io/antrea/bd881183db8a59bd2cc687bf1f7d70337e5d7b2c/hack/windows/Helper.psm1" = "C:/k/antrea/Helper.psm1"
+      # Antrea 1.4.0 binaries
       "https://github.com/antrea-io/antrea/releases/download/v1.4.0/antrea-agent-windows-x86_64.exe" = "C:/k/antrea/bin/antrea-agent.exe"
       "https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-windows-amd64-v0.9.1.tgz" = "C:/k/antrea/bin/cni-plugins-windows-amd64-v0.9.1.tgz"
       "https://gist.githubusercontent.com/knabben/5dec7c059916d3b487aeb2efd3a689b6/raw/90d50749fbce55fd80080d40585f14ce1e20b06a/antrea.yaml" = "C:/k/antrea/etc/antrea-agent.conf"
       # this is on jay's bucket because its otherwise a flakey download or not existent
-      "https://storage.googleapis.com/jayunit100/Win64OpenSSL-3_0_3.exe" = "C:/ssl.exe"
+      "https://github.com/knabben/k8s-graph/files/8855631/libeay32.txt" = "c:\Windows\System32\libeay32.dll"
+      "https://github.com/knabben/k8s-graph/files/8855633/libssl32.txt" = "c:\Windows\System32\libssl32.dll"
+      "https://github.com/knabben/k8s-graph/files/8855645/ssleay32.txt" = "c:\Windows\System32\ssleay32.dll"
       "https://storage.googleapis.com/jayunit100/vcd.exe" = "C:/vcd.exe"
 }
 
@@ -76,11 +78,9 @@ foreach ($theURL in $antreaInstallationFiles.keys) {
 Write-Output("Now trying to execute VCD.exe")
 C:/vcd.exe /quiet /norestart
 
-Write-Output("Now trying to execute SSL.exe")
-C:/ssl.exe /silent /verysilent /sp- /suppressmsgboxes
-
 # Signing binaries
 Bcdedit.exe -set TESTSIGNING ON
 
+# Wait for installations in the background
 Start-Sleep -s 30
 Restart-Computer

--- a/sync/windows/1-antrea.ps1
+++ b/sync/windows/1-antrea.ps1
@@ -17,6 +17,9 @@ Param(
     [parameter(HelpMessage="Windows Node IP")]
     [string] $windowsNodeIP = "10.20.30.11"
 )
+
+Set-PSDebug -Trace 1
+
 $ErrorActionPreference = 'Stop'
 
 $folders = @('C:\k\antrea','C:\var\log\antrea','C:\k\antrea\bin', 'C:\var\log\kube-proxy', 'C:\opt\cni\bin', 'C:\etc\cni\net.d')


### PR DESCRIPTION
1. Using tagged helper.psm1 installation script, before was getting from master and a latest change broke the install script - https://github.com/antrea-io/antrea/pull/3730
2. SSL.exe installation is not working instead downloading the OVS DLL dependencies directly

TODO: Need to change these files to the bucket.