### PR TITLE
CNI: antrea uses different SA during deploy

### DIFF
--- a/sync/windows/1-antrea.ps1
+++ b/sync/windows/1-antrea.ps1
@@ -58,7 +58,7 @@ $KubeConfigFile='C:\etc\kubernetes\kubelet.conf'
 # Setup kube-proxy config file
 $KubeProxyConfig="C:/k/antrea/etc/kube-proxy.conf"
 $KubeAPIServer=$(kubectl --kubeconfig=$KubeConfigFile config view -o jsonpath='{.clusters[0].cluster.server}')
-$KubeProxyTOKEN=$(kubectl --kubeconfig=$KubeConfigFile get secrets -n kube-system -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='kube-proxy-windows')].data.token}")
+$KubeProxyTOKEN=$(kubectl --kubeconfig=$KubeConfigFile get secrets -n kube-system -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='antrea-agent')].data.token}")
 $KubeProxyTOKEN=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($KubeProxyTOKEN)))
 
 # This writes out a kubeconfig file... i think !


### PR DESCRIPTION
In the Antrea deploy, there no service account called kube-proxy-windows
for getting the token from secret (only antrea-agent). This patch
sets antrea-agent for the initial token collection.

Resolves: https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/198

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>