### PR TITLE
Replacing k8s.grc.io with registry.k8s.io

### DIFF
--- a/sync/linux/wine2e.yaml
+++ b/sync/linux/wine2e.yaml
@@ -43,7 +43,7 @@ spec:
       value: --progress-report-url=http://localhost:8099/progress --node-os-distro=windows
     - name: KUBE_TEST_REPO_LIST
       value: /tmp/sonobuoy/config/image-repo-list-master
-  image: k8s.gcr.io/conformance:$SONOBUOY_K8S_VERSION
+  image: registry.k8s.io/conformance:$SONOBUOY_K8S_VERSION
   imagePullPolicy: Always
   name: e2e
   resources: {}


### PR DESCRIPTION
As part of https://github.com/kubernetes/k8s.io/issues/4738 updated `k8s.grc.io` with `registry.k8s.io`