### PR TITLE
Update variables.yaml with Kubernetes 1.27

### DIFF
--- a/variables.yaml
+++ b/variables.yaml
@@ -1,5 +1,5 @@
 # Kubernetes version, pick major and minor, patch will be the latest released.
-kubernetes_version: "1.26"
+kubernetes_version: "1.27"
 
 # if this options is used BINARIES will be downloaded instead of building from zero
 build_from_source: "false"


### PR DESCRIPTION
I think it is reasonable to update this to latest release, because Kubernetes on controlplane node is installed from 
```
  deb https://apt.kubernetes.io/ kubernetes-xenial main
```
which apparently provides package with the latest.

This should also clear the following warning:

```
  controlplane: [WARNING KubeletVersion]:
    the kubelet version is higher than the control plane version.
    This is not a supported version skew and may lead to a malfunctional cluster.
    Kubelet version: "1.27.1" Control plane version: "1.26.4"
```