### PR TITLE
Add make.ps1 as Windows-native Makefile equivalent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ sync/shared/kubeadm.yaml
 sync/shared/variables.yaml
 kubernetes
 .vagrant/
+variables.local.yaml
 
 # semaphores during build
 .lock/
 .idea/
+
+# make.ps1 produces log files in project root
+/*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,6 +86,7 @@ Vagrant.configure(2) do |config|
     winw1.vm.host_name = "winw1"
     winw1.vm.box = "sig-windows-dev-tools/windows-2019"
     winw1.vm.box_version = "1.0"
+    winw1.vm.boot_timeout = 900
 
     winw1.vm.provider :virtualbox do |vb|
       vb.memory = windows_ram

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,15 @@ Vagrant.configure(2) do |config|
     controlplane.vm.synced_folder "./sync/linux", "/var/sync/linux"
       vb.memory = linux_ram
       vb.cpus = linux_cpus
+      # Enabling I/O APIC is required for 64-bit guests
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      # Force newer VirtualBox default graphics controller for Linux guests
+      vb.customize ['modifyvm', :id, '--graphicscontroller', 'vmsvga']
+      # Explicitly disable unnecessary features for better performance
+      vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+      vb.customize ["modifyvm", :id, "--accelerate2dvideo", "off"]
+      vb.customize ['modifyvm', :id, '--clipboard', 'disabled']
+      vb.customize ['modifyvm', :id, '--draganddrop', 'disabled']
     end
 
     ### This allows the node to default to the right IP i think....
@@ -81,6 +90,17 @@ Vagrant.configure(2) do |config|
     winw1.vm.provider :virtualbox do |vb|
       vb.memory = windows_ram
       vb.cpus = windows_cpus
+      # Enabling I/O APIC is required for 64-bit guests
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      # Explicitly use Windows guest default graphics controller
+      vb.customize ['modifyvm', :id, '--graphicscontroller', 'vboxsvga']
+      # Explicitly disable unnecessary features for better performance
+      vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+      vb.customize ["modifyvm", :id, "--accelerate2dvideo", "off"]
+      vb.customize ['modifyvm', :id, '--clipboard', 'disabled']
+      vb.customize ['modifyvm', :id, '--draganddrop', 'disabled']
+      # Use paravirtualization provider VirtualBox recommends for Windows guests
+      vb.customize ["modifyvm", :id, "--paravirt-provider", "hyperv"]
       vb.gui = false
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,9 +118,9 @@ Vagrant.configure(2) do |config|
     winw1.vm.provision "shell", inline: "netsh advfirewall set allprofiles state off"
 
     if not File.file?(".lock/joined") then
-     # Update containerd
-     winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
+      # Update containerd
       puts "[Vagrantfile] calico: #{calico_version}; containerd: #{containerd_version}"
+      winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
 
       # Joining the controlplane
       winw1.vm.provision "shell", path: "sync/windows/forked.ps1", args: "#{kubernetes_version}", privileged: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,6 +114,9 @@ Vagrant.configure(2) do |config|
     winw1.winrm.username = "vagrant"
     winw1.winrm.password = "vagrant"
 
+    # Turn off Windows Firewall for apparent better performance
+    winw1.vm.provision "shell", inline: "netsh advfirewall set allprofiles state off"
+
     if not File.file?(".lock/joined") then
      # Update containerd
      winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,19 +3,20 @@
 require 'yaml'
 require 'fileutils'
 
-# Modify these in the variables.yaml file... they are described there in gory detail...
-# This will get copied down later to synch/shared/variables... and read by the controlplane.sh etc...
-settingsFile = "variables.yaml" || ENV["VAGRANT_VARIABLES"]
+# Give user-defined variables file higher precedence, for example, make.ps1
+# searches for user-specific variables.local.yaml and assigns VAGRANT_VARIABLES.
+# Otherwise, use the provided variables.yaml with defaults.
+# This settings file will be copied to sync/shared/variables.yaml for controlplane.sh.
+settingsFile = ENV["VAGRANT_VARIABLES"] || "variables.yaml"
+puts "[Vagrantfile] settings: #{settingsFile}"
 FileUtils.cp(settingsFile, "sync/shared/variables.yaml")
 settings = YAML.load_file settingsFile
-
 
 kubernetes_version=settings["kubernetes_version"]
 k8s_linux_kubelet_nodeip=settings['k8s_linux_kubelet_nodeip']
 pod_cidr=settings['pod_cidr']
 calico_version=settings['calico_version']
 containerd_version=settings['containerd_version']
-
 
 linux_ram = settings['linux_ram']
 linux_cpus = settings['linux_cpus']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ windows_node_ip = settings['windows_node_ip']
 cni = settings['cni']
 
 Vagrant.configure(2) do |config|
-  puts "cni: #{cni}"
+  puts "[Vagrantfile] cni: #{cni}"
 
 #   LINUX Control Plane
   config.vm.define :controlplane do |controlplane|
@@ -80,8 +80,8 @@ Vagrant.configure(2) do |config|
 
     if not File.file?(".lock/joined") then
      # Update containerd
-     puts "calico: #{calico_version}; containerd: #{containerd_version}"
      winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
+      puts "[Vagrantfile] calico: #{calico_version}; containerd: #{containerd_version}"
 
       # Joining the controlplane
       winw1.vm.provision "shell", path: "sync/windows/forked.ps1", args: "#{kubernetes_version}", privileged: true

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,280 @@
+# Prepares and runs Kubernetes cluster on Windows host from PowerShell command line.
+# This is supposed to offer euiqvalent functionality as the provided Makefile,
+# but without requirement of GNU Make, that is, running the procedure from WSL.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:startTime = (Get-Date)
+
+#region Helper Fuctions
+function script:Write-Log {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$msg1
+    )
+    Begin {
+        $savedForegroundColor = $host.UI.RawUI.ForegroundColor
+        $timestamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+    }
+    Process {
+        $host.UI.RawUI.ForegroundColor = 'DarkGreen'
+        $scriptTag = (Split-Path -Path $PSCommandPath -Leaf)
+        Write-Output ('{0} [{1}] {2}' -f $timestamp, $scriptTag, $msg1)
+    }
+    End {
+        $host.UI.RawUI.ForegroundColor = $savedForegroundColor
+    }
+}
+
+# Get-SettingsVaribale <setting property key>
+function Get-SettingsVariable
+{
+    $settingsFile = $env:VAGRANT_VARIABLES
+    if (-not $settingsFile) {
+        Write-Log "WARNING: Environment variable VAGRANT_VARIABLES not defined"
+        $settingsFile = Resolve-Path -Path ".\variables.yaml"
+    }
+    Get-Content -Path $settingsFile |
+        Select-String -Pattern ('^{0}.*\:.+' -f $args[0]) |
+        ForEach-Object { ($_ -Split ':').Trim().Trim('"') } |
+        Select-Object -Last 1
+}
+
+function script:Set-PrivateKeyPermissions {
+    Write-Log 'Fixing permissions of Vagrant SSH private keys'
+    Get-ChildItem -Path (Get-Location) -Name 'private_key' -Recurse | ForEach-Object {
+        New-Variable -Name Key -Value $_
+        icacls $Key /c /t /Inheritance:d
+        icacls $Key /c /t /Grant ${env:UserName}:F
+        takeown /F $Key
+        icacls $Key /c /t /Grant:r ${env:UserName}:F
+        icacls $Key /c /t /Remove:g Administrator 'Authenticated Users' BUILTIN\Administrators BUILTIN Everyone System Users
+        icacls $Key
+        Remove-Variable -Name Key
+    }
+}
+
+function script:Remove-VagrantEnv {
+    Remove-Item -Path env:VAGRANT -ErrorAction SilentlyContinue
+    Remove-Item -Path env:VAGRANT_VARIABLES -ErrorAction SilentlyContinue
+}
+
+function script:Set-VagrantEnv {
+    script:Remove-VagrantEnv
+
+    $v = (Get-Command -Name 'vagrant.exe' -ErrorAction Stop)
+    Write-Log ('Running {0} from {1}' -f (& $v --version), $v.Source)
+
+    # Select user-specific local variables, if present
+    if (Test-Path -Path 'variables.local.yaml' -PathType Leaf) {
+        $variablesFile = (Resolve-Path -Path 'variables.local.yaml')
+    }
+    else {
+        $variablesFile = (Resolve-Path -Path 'variables.yaml' )
+    }
+    Set-Item -Path env:VAGRANT_VARIABLES -Value $variablesFile
+    Write-Log "Setting Vagrant variables from $env:VAGRANT_VARIABLES"
+}
+#endregion Helper Fuctions
+
+#region Command Functions
+function script:Invoke-Clean {
+    Write-Log 'Invoking command: clean'
+    vagrant destroy --force
+    @(
+        '.\sync\linux\bin',
+        '.\sync\windows\bin',
+        '.\sync\shared\config',
+        '.\sync\shared\kubeadm.yaml',
+        '.\sync\shared\kubejoin.ps1',
+        '.\sync\shared\variables.yaml',
+        '.\.lock',
+        '.\.vagrant'
+    ) | ForEach-Object {
+        if (Test-Path $_) {
+            Write-Log "Cleaning $_"
+            Remove-Item -Path "$_" -Recurse -Force
+        }
+    }
+    Write-Log 'Log files have not been deleted, run: Remove-Item *.log'
+}
+
+function script:Invoke-Download {
+    # This is settings check only as this property does not really control the make.ps1 workflow
+    # That is becasue make.ps1 steps are invoked individually one-by-one (not like dependency-based Makefile targets)
+    $buildFromSource = (Get-SettingsVariable "build_from_source") -eq 'false' ? $false : $true
+    if ($buildFromSource) {
+        throw "TODO: Build from source"
+    }
+    $kubernetesVersion = (Get-SettingsVariable "kubernetes_version")
+    Write-Log ("Using requested Kubernetes version {0}" -f $kubernetesVersion)
+
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+    $kubernetesVersion = (New-Object System.Net.WebClient).DownloadString(("https://storage.googleapis.com/k8s-release-dev/ci/latest-{0}.txt" -f $kubernetesVersion))
+    $kubernetesTag = ($kubernetesVersion -split '+', 2, "SimpleMatch" | Select-Object -First 1)
+    $kubernetesSha = ($kubernetesVersion -split '+', 2, "SimpleMatch" | Select-Object -Last 1)
+    if (-not $kubernetesTag -or -not $kubernetesSha) {
+        throw "Unknown Kubernetes tag and hash for version $kubernetesVersion"
+    }
+    Write-Log ("Downloading Kubernetes version {0}-{1} from upstream" -f $kubernetesTag, $kubernetesSha)
+    
+    $linuxBinDir = Join-Path -Path (Get-Location) -ChildPath '.\sync\Linux\bin'
+    $windowsBinDir = Join-Path -Path (Get-Location) -ChildPath '.\sync\windows\bin'
+    if (-not (Test-Path -Path $linuxBinDir -PathType Container)) {
+        New-Item -Path $linuxBinDir -ItemType Directory -Force -ErrorAction Stop | Out-Null
+    }
+    if (-not (Test-Path -Path $windowsBinDir -PathType Container)) {
+        New-Item -Path $windowsBinDir -ItemType Directory -Force -ErrorAction Stop | Out-Null
+    }
+    
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+    $webClient = New-Object System.Net.WebClient
+    # Linux binaries
+    @('kubeadm', 'kubectl', 'kubelet') | ForEach-Object {
+        $bin = $_
+        $url = ("https://storage.googleapis.com/k8s-release-dev/ci/{0}/bin/linux/amd64/{1}" -f $kubernetesVersion, $bin)
+        Write-Log ('Downloading {0}' -f $url)
+        $webClient.DownloadFile($url, (Join-Path -Path $linuxBinDir -ChildPath $bin))
+        # NOTICE: controlplane.sh executes chmod +x
+    }
+    # Windows binaries
+    @('kubeadm', 'kubelet', 'kube-proxy') | ForEach-Object {
+        $bin = $_
+        $url = ("https://storage.googleapis.com/k8s-release-dev/ci/{0}/bin/windows/amd64/{1}.exe" -f $kubernetesVersion, $bin)
+        Write-Log ('Downloading {0}' -f $url)
+        $webClient.DownloadFile($url, (Join-Path -Path $windowsBinDir -ChildPath ('{0}.exe' -f $bin)))
+    }
+}
+
+function script:Invoke-Run {
+    Write-Log 'Invoking command: run'
+    
+    Write-Log 'Creating .\.lock directory'
+    if (Test-Path '.\.lock') {
+        Remove-Item -Path '.\.lock' -Recurse -Force | Out-Null
+    }
+    New-Item -Path '.\.lock' -ItemType Directory -Force | Out-Null
+    Write-Log 'Creating .\sync\shared\kubejoin.ps1 mock file to keep Vagrantfile happy'
+    New-Item -Path '.\sync\shared\kubejoin.ps1' -ItemType File -Force | Out-Null
+
+    ###### Linux node
+    Write-Log 'vagrant up controlplane'
+    vagrant up controlplane
+    if ($LASTEXITCODE -ne 0) { throw 'Vagrant error' }
+
+    Write-Log 'vagrant status'
+    vagrant status
+
+    ###### Windows node
+    $count = 1
+    while ($true) {
+        $vagrantStatus = $(vagrant status winw1 | Select-String -Pattern 'winw1' | ForEach-Object { $_ -split '\s{2,}' } | Select-Object -Last 1)
+        Write-Log ('vagrant status winw1 - attempt {0} - status: {1}' -f $count, $vagrantStatus)
+        if ($vagrantStatus -match 'running') {
+            break
+        }
+        Write-Log ('vagrant up winw1 - attempt {0}' -f $count)
+        vagrant up winw1
+        $count += 1
+    }
+
+    # Correct SSH key files permissions, otherwise vagrant ssh will keep prompting
+    # for password what defeats the non-interactive purpose of the whole procedure.
+    Set-PrivateKeyPermissions
+
+    $count = 1
+    while ($true) {
+        Write-Log ('kubectl get nodes | grep winw1 - attempt {0}' -f $count)
+        if (vagrant ssh controlplane -c 'kubectl get nodes' | Select-String -SimpleMatch 'winw1') {
+            break
+        }
+        Write-Log ('vagrant provision winw1 - attempt {0}' -f $count)
+        vagrant provision winw1
+        $count += 1
+    }
+
+    Write-Log 'Creating .\.lock\joined indicator for Vagrantfile'
+    New-Item -Path '.\.lock\joined' -ItemType File -Force
+    Write-Log ('vagrant provision winw1 - attempt {0}' -f $count)
+    vagrant provision winw1
+
+    Write-Log 'Creating .\.lock\cni indicator for Vagrantfile'
+    New-Item -Path '.\.lock\cni' -ItemType File -Force
+
+    Write-Log 'Cluster created'
+    vagrant status
+    vagrant ssh controlplane -c 'kubectl get nodes'
+}
+
+function script:Invoke-Status {
+    Write-Log 'Invoking command: status'
+
+    Write-Log 'vagrant status'
+    vagrant status
+    
+    Write-Log 'kubectl get nodes'
+    vagrant ssh controlplane -c 'kubectl get nodes'
+}
+#endregion Command Functions
+
+#region Main Script
+$commands = @{
+    'clean'      = '0. Start fresh destroying any existing Vagrant machines';
+    'download'   = '1. Download Kubernetes binaries for Linux and Windows (set version in variables.yaml or variables.local.yaml)';
+    'build'      = '2. Optionally, build Kubernetes from sources for Linux and Windows';
+    'run'        = '3. Create and run two-node cluster';
+    'status'     = '4. Check state of Vagrant machines and Kubernetes nodes';
+    'smoke-test' = '5. Run smoke tests';
+    'e2e-test'   = '6. Run end-to-end tests';
+    'help'       = 'Print this message';
+}
+
+if ($args.Count -eq 0 -or $commands.Keys -notcontains $args[0] -or $args[0] -contains 'help') {
+    Write-Host "Usage: .\make.ps1 <command>"
+    Write-Host "`nRun commands one by one in the following order:"
+    $commands.GetEnumerator() | Sort-Object -Property Value | Format-Table -HideTableHeaders -AutoSize
+    Write-Host "`nDefault settings are defined in variables.yaml file."
+    Write-Host "To tweak the defaults, make a copy as variables.local.yaml and edit.`n"
+    exit
+}
+
+script:Set-VagrantEnv
+
+$command = $args[0]
+if ($command -eq 'clean') {
+    script:Invoke-Clean
+}
+elseif ($command -eq 'status') {
+    script:Invoke-Status
+}
+else {
+    $logTime = (Get-Date -Date $script:startTime -UFormat '%Y%m%d%H%M%S')
+    $logFile = (Join-Path -Path (Get-Location) -ChildPath ('make-{0}-{1}.log' -f $command, $logTime))
+    Write-Log "Saving command output to $logFile"
+    
+    if ($command -eq 'download') {
+        script:Invoke-Download | Tee-Object -FilePath $logFile
+    }
+    elseif ($command -eq 'build') {
+        Write-Host 'TODO: Invoke-Build'
+        #script:Invoke-Build | Tee-Object -FilePath $logFile
+    }
+    elseif ($command -eq 'run') {
+        script:Invoke-Run | Tee-Object -FilePath $logFile
+    }
+    elseif ($command -eq 'smoke-test') {
+        Write-Host 'TODO: Invoke-SmokeTest'
+        #script:Invoke-SmokeTest | Tee-Object -FilePath $logFile
+    }
+    elseif ($command -eq 'e2e-test') {
+        Write-Host 'TODO: Invoke-EndToEndTest'
+        #script:Invoke-EndToEndTest | Tee-Object -FilePath $logFile
+    }
+}
+
+script:Remove-VagrantEnv
+
+Write-Log ('Finished in {0:N2} minutes' -f ((Get-Date) - $startTime).TotalMinutes)
+#endregion Main Script

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -115,6 +115,7 @@ do
   if [ -f $file ]; then
     echo "copying $file to node path.."
     sudo cp $file /usr/bin/ -f
+    sudo chmod +x /usr/bin/$BIN
   fi
 done
 

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -159,6 +159,9 @@ cp $HOME/.kube/config /var/sync/shared/config
 rm -f /var/sync/shared/kubejoin.ps1
 
 cat << EOF > /var/sync/shared/kubejoin.ps1
+if(!(Test-Path ("C:\Program Files\containerd\crictl.exe"))) {
+    mv "C:\Users\vagrant\crictl.exe" "C:\Program Files\containerd\"
+}
 stop-service -name kubelet
 cp C:\sync\windows\bin\* c:\k
 


### PR DESCRIPTION
This PowerShell-base prototype as proof of concept inspired by @luthermonson's
- #203 

## Features

`make.ps1` prepares and runs Kubernetes cluster on Windows host from PowerShell command line as equivalent functionality of the currently provided [Makefile](https://github.com/kubernetes-sigs/sig-windows-dev-tools/blob/dc49c60245cc848aed65f3dced8a75063e872b69/Makefile), but without requirement of GNU Make, that is, [running the procedure from WSL](https://github.com/kubernetes-sigs/sig-windows-dev-tools/blob/dc49c60245cc848aed65f3dced8a75063e872b69/README.md#windows-with-wsl).

`make.ps1` allows users to override default `variables.yaml` with custom `variables.local.yaml` without modifying versioned files, or via any other file set via `VAGRANT_VARIABLES` environment variable.

There is no documentation update included, but I've taken care to make `.\make.ps1 help` clear and easy to follow, which is this:

```
.\make.ps clean
.\make.ps download
.\make.ps run
.\make.ps status
```

I was thinking about adding `README.windows.md` with detailed notes, but that could unnecessarily add up mess to the set of existing files `README.md`, `WINDOWS.md`, `README_VMWARE.md`. I am willing to improve the docs as soon as this PR is approved and merged.

There is several missing features/commands:
- to build Kubernetes from sources on Windows host
- to run smoke and end-to-end tests

Those are not difficult to add and I will work on it as soon as this PR is approved and merged.

Generally, IMHO, we need to get the basic framework in place first in order to enable ourselves to start testing the cluster setup on Windows host directly as soon as possible.

## Additional Changes

- Upgrades control plane box from Ubuntu 20.04 to 22.04 LTS (see [#sig-windows discussion thread](https://kubernetes.slack.com/archives/C0SJ4AFB7/p1681841932987749). This can close #253
- Enables required and disables unused VirtualBox machine features for maximum performance (it looks like the stack creation time is 20-25% faster). Based on VirtualBox manual and well-known issues documented on the web.
- Disable Windows Firewall on Windows Server 2019 as unnecessary and for maximum overall performance.
- Fixes the known `crictl.exe file not found in %PATH%` regression reported in #248 by myself
