### PR TITLE
Fix crictl.exe file not found in %PATH% regression

### DIFF
--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -158,6 +158,9 @@ cp $HOME/.kube/config /var/sync/shared/config
 rm -f /var/sync/shared/kubejoin.ps1
 
 cat << EOF > /var/sync/shared/kubejoin.ps1
+if(!(Test-Path ("C:\Program Files\containerd\crictl.exe"))) {
+    mv "C:\Users\vagrant\crictl.exe" "C:\Program Files\containerd\"
+}
 stop-service -name kubelet
 cp C:\sync\windows\bin\* c:\k
 


### PR DESCRIPTION
This restores change from
- #145 

to address

- #248

----

Extracted from bundle
- #254 