### PR TITLE
Ensure copied Kubernetes binaries are executable

### DIFF
--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -115,6 +115,7 @@ do
   if [ -f $file ]; then
     echo "copying $file to node path.."
     sudo cp $file /usr/bin/ -f
+    sudo chmod +x /usr/bin/$BIN
   fi
 done
 


### PR DESCRIPTION
Currently, the binaries are `chmod`-ed during download phase

https://github.com/kubernetes-sigs/sig-windows-dev-tools/blob/171f2ca763ea90d19e996bcc28a055ba1086c09b/build.sh#L29

which does not seem to be the best place to do it, besides this step may not be effective (i.e. is missing) when run on Windows host. That is, if binaries are downloaded and copied by other means than the `Makefile`, e.g. `make.ps1` from #254, then those binaries are missing executable bit.

-----

Extracted from bundle

- #254 