### PR TITLE
Vagrantfile: Clean up accidentally interleaved vm.provider and vm.synced_folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,13 +34,15 @@ Vagrant.configure(2) do |config|
     controlplane.vm.box = "roboxes/ubuntu2004"
 
     controlplane.vm.network :private_network, ip:"#{k8s_linux_kubelet_nodeip}"
+
     controlplane.vm.provider :virtualbox do |vb|
-    controlplane.vm.synced_folder "./sync/shared", "/var/sync/shared"
-    controlplane.vm.synced_folder "./forked", "/var/sync/forked"
-    controlplane.vm.synced_folder "./sync/linux", "/var/sync/linux"
       vb.memory = linux_ram
       vb.cpus = linux_cpus
     end
+    
+    controlplane.vm.synced_folder "./sync/shared", "/var/sync/shared"
+    controlplane.vm.synced_folder "./forked", "/var/sync/forked"
+    controlplane.vm.synced_folder "./sync/linux", "/var/sync/linux"
 
     ### This allows the node to default to the right IP i think....
     # 1) this seems to break the ability to get to the internet

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ cni = settings['cni']
 Vagrant.configure(2) do |config|
   puts "cni: #{cni}"
 
-#   LINUX Control Plane
+  # LINUX Control Plane
   config.vm.define :controlplane do |controlplane|
     controlplane.vm.host_name = "controlplane"
     controlplane.vm.box = "roboxes/ubuntu2004"
@@ -80,9 +80,8 @@ Vagrant.configure(2) do |config|
     winw1.winrm.password = "vagrant"
 
     if not File.file?(".lock/joined") then
-     # Update containerd
-     puts "calico: #{calico_version}; containerd: #{containerd_version}"
-     winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
+      # Update containerd
+      winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
 
       # Joining the controlplane
       winw1.vm.provision "shell", path: "sync/windows/forked.ps1", args: "#{kubernetes_version}", privileged: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ require 'fileutils'
 # Modify these in the variables.yaml file... they are described there in gory detail...
 # This will get copied down later to synch/shared/variables... and read by the controlplane.sh etc...
 settingsFile = "variables.yaml" || ENV["VAGRANT_VARIABLES"]
+puts "[Vagrantfile] Loading settings from #{settingsFile}"
 FileUtils.cp(settingsFile, "sync/shared/variables.yaml")
 settings = YAML.load_file settingsFile
 
@@ -26,7 +27,8 @@ windows_node_ip = settings['windows_node_ip']
 cni = settings['cni']
 
 Vagrant.configure(2) do |config|
-  puts "cni: #{cni}"
+  puts "[Vagrantfile] Using Kubernetes version: #{kubernetes_version}"
+  puts "[Vagrantfile] Using Kubernetes CNI implementation: #{cni}"
 
   # LINUX Control Plane
   config.vm.define :controlplane do |controlplane|
@@ -52,6 +54,7 @@ Vagrant.configure(2) do |config|
     # TODO shoudl we pass KuberneteVersion to calico agent exe? and also service cidr if needed?
     # dont run as priveliged cuz we need the kubeconfig from regular user
     if cni == "calico" then
+      puts "[Vagrantfile] Provisioning controlplane with Calico: #{calico_version}"
       controlplane.vm.provision "shell", path: "sync/linux/calico-0.sh", args: "#{pod_cidr} #{calico_version}"
     else
       controlplane.vm.provision "shell", path: "sync/linux/antrea-0.sh"
@@ -81,6 +84,7 @@ Vagrant.configure(2) do |config|
 
     if not File.file?(".lock/joined") then
       # Update containerd
+      puts "[Vagrantfile] Provisioning winw1 node with Calico: #{calico_version}; containerd: #{containerd_version}"
       winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
 
       # Joining the controlplane


### PR DESCRIPTION
Additionally:
- Clean up indentation
- Clear up messages sent from Vagrantfile; tag them with source

---

@jayunit100 @aravindhp  This is just a bit of clean up and refactoring - I'm updating Vagrantfile with VirtualBox tweaks and it would be helpful to get this one in.