### PR TITLE
Switch to custom Vagrant boxes and Magefiles instead of Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ sync/shared/kubeadm.yaml
 sync/shared/variables.yaml
 kubernetes
 .vagrant/
+variables.local.yaml
 
 # semaphores during build
 .lock/
 .idea/
+
+# logs during build
+*.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Welcome to the SIG Windows Development Environment!
 
 This is a fully batteries-included development environment for Windows on Kubernetes, including:
+
 - Vagrant file for launching a two-node cluster
 - The latest Containerd
 - Support for two CNIs: antrea, or calico on containerd:  configure your CNI option in variables.yml
@@ -12,9 +13,14 @@ This is a fully batteries-included development environment for Windows on Kubern
 
 ## Quick Start
 
-### Prerequisites 
-- Linux host - mostly tested on [Ubuntu](#ubuntu). Alternatively, Windows host with WSL as environment providing `make`, see [Windows with WSL](#windows-with-wsl).
-- [make](https://www.gnu.org/software/make/)
+### Prerequisites
+
+- Linux host - mostly tested on [Ubuntu](#ubuntu).- Alternatively, Windows host with either
+  - WSL as environment providing `make`, see [Windows with WSL](#windows-with-wsl)
+  - Go and Mage, see [Windows Natively](#windows-natively).
+
+- [Go](https://go.dev)
+- [Mage](https://magefile.org)
 - [Vagrant](https://www.vagrantup.com/downloads)
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (we only have VirtualBox automated here, but these recipes have been used with others, like Microsoft HyperV and VMware Fusion).
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
@@ -25,12 +31,13 @@ Simple steps to a Windows Kubernetes cluster, from scratch, built from source...
 
 - `vagrant plugin install vagrant-reload vagrant-vbguest winrm winrm-elevated`, vagrant-reload needed to easily reboot windows VMs during setup of containers features.
 - `make all`, this will create the entire cluster for you.  To compile k/k/ from local source, see instructions later in this doc. 
-	- *If the above failed, run `vagrant provision winw1`, just in case you have a flake during windows installation.*
+  - *If the above failed, run `vagrant provision winw1`, just in case you have a flake during windows installation.*
 - `vagrant ssh controlplane` and run `kubectl get nodes` to see your running dual-os linux+windows k8s cluster.
 
 ## Windows with WSL
 
 All the above Quick Start steps apply, except you have to run the `Makefile` targets in WSL
+
 - using `vagrant.exe` on the host
 - while inside clone of this repo on Windows filesystem, not WSL filesystem.
 
@@ -45,7 +52,7 @@ Next, pass the mount path to the executable on the Windows host with the `VAGRAN
 
 Then, ensure you clone this repository onto filesystem inside `/mnt` and not the WSL filesystem, in order to avoid failures similar to this one:
 
-```
+```console
 The host path of the shared folder is not supported from WSL.
 Host path of the shared folder must be located on a file system with
 DrvFs type. Host path: ./sync/shared
@@ -61,6 +68,27 @@ make all
 # ...
 make clean
 ```
+
+## Windows Natively
+
+All the above Quick Start steps apply, except that on Windows host directly you can use the provided [Magefiles](https://magefile.org) written in Go instead of the `Makefile`:
+
+```console
+mage all
+```
+
+which is equivalent of step-by-step invocation:
+
+```console
+mage fetch
+mage run
+```
+
+This variant of the workflow deploys Kubernetes from the official binaries.
+
+Run `mage status` to query status of Vagrant machines status and Kubernetes nodes.
+
+Run `mage clean` to delete the whole cluster and start fresh.
 
 ## Ubuntu
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,19 +3,23 @@
 require 'yaml'
 require 'fileutils'
 
-# Modify these in the variables.yaml file... they are described there in gory detail...
-# This will get copied down later to synch/shared/variables... and read by the controlplane.sh etc...
-settingsFile = "variables.yaml" || ENV["VAGRANT_VARIABLES"]
+# Magefiles search for user-specific variables.local.yaml and set ENV[VAGRANT_VARIABLES],
+# otherwise fallback to use the provided variables.yaml with default settings.
+# The settings file is also copied to sync/shared/variables.yaml and used by controlplane scripts.
+settingsFile = ENV["VAGRANT_VARIABLES"] || "variables.yaml"
+if ENV["VAGRANT_VARIABLES"]
+  puts "[Vagrantfile] Loading settings from ENV[VAGRANT_VARIABLES]=#{settingsFile}"
+else
+  puts "[Vagrantfile] Loading default settings from #{settingsFile}"
+end
 FileUtils.cp(settingsFile, "sync/shared/variables.yaml")
 settings = YAML.load_file settingsFile
-
 
 kubernetes_version=settings["kubernetes_version"]
 k8s_linux_kubelet_nodeip=settings['k8s_linux_kubelet_nodeip']
 pod_cidr=settings['pod_cidr']
 calico_version=settings['calico_version']
 containerd_version=settings['containerd_version']
-
 
 linux_ram = settings['linux_ram']
 linux_cpus = settings['linux_cpus']
@@ -26,21 +30,37 @@ windows_node_ip = settings['windows_node_ip']
 cni = settings['cni']
 
 Vagrant.configure(2) do |config|
-  puts "cni: #{cni}"
 
-#   LINUX Control Plane
+  ############ Linux Control Plane node ############
   config.vm.define :controlplane do |controlplane|
     controlplane.vm.host_name = "controlplane"
-    controlplane.vm.box = "roboxes/ubuntu2004"
+    controlplane.vm.box = "mloskot/sig-windows-dev-tools-ubuntu-2204"
+    controlplane.vm.box_version = "1.0"
+    controlplane.vm.boot_timeout = 900
 
     controlplane.vm.network :private_network, ip:"#{k8s_linux_kubelet_nodeip}"
     controlplane.vm.provider :virtualbox do |vb|
+      vb.memory = linux_ram
+      vb.cpus = linux_cpus
+      vb.gui = false
+      # Explicitly  Windows guest version and type
+      vb.customize ["modifyvm", :id, "--ostype", 'Ubuntu22_LTS_64']
+      # Enabling I/O APIC is required for 64-bit guests
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      # Force newer VirtualBox default graphics controller for Linux guests
+      vb.customize ['modifyvm', :id, '--graphicscontroller', 'vmsvga']
+      # Explicitly disable unnecessary features for better performance
+      vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+      vb.customize ["modifyvm", :id, "--accelerate2dvideo", "off"]
+      vb.customize ['modifyvm', :id, '--clipboard', 'disabled']
+      vb.customize ['modifyvm', :id, '--draganddrop', 'disabled']
+      vb.customize ['modifyvm', :id, '--vrde', 'off']
+    end
+    
+    controlplane.vm.synced_folder ".", "/vagrant", disabled:true
     controlplane.vm.synced_folder "./sync/shared", "/var/sync/shared"
     controlplane.vm.synced_folder "./forked", "/var/sync/forked"
     controlplane.vm.synced_folder "./sync/linux", "/var/sync/linux"
-      vb.memory = linux_ram
-      vb.cpus = linux_cpus
-    end
 
     ### This allows the node to default to the right IP i think....
     # 1) this seems to break the ability to get to the internet
@@ -56,16 +76,30 @@ Vagrant.configure(2) do |config|
     end
   end
 
-  # WINDOWS WORKER (win server 2019)
+  ############ Windows worker node #1 ############
   config.vm.define :winw1 do |winw1|
-    winw1.vm.host_name = "winw1"
-    winw1.vm.box = "sig-windows-dev-tools/windows-2019"
+    winw1.vm.box = "mloskot/sig-windows-dev-tools-windows-2019"
     winw1.vm.box_version = "1.0"
+    winw1.vm.communicator = "winrm"
+    winw1.vm.guest = :windows
+    winw1.vm.boot_timeout = 900
 
     winw1.vm.provider :virtualbox do |vb|
       vb.memory = windows_ram
       vb.cpus = windows_cpus
       vb.gui = false
+      # Explicitly  Windows guest version and type
+      vb.customize ["modifyvm", :id, "--ostype", 'Windows2019_64']
+      # Enabling I/O APIC is required for 64-bit guests
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      # Explicitly use Windows guest default graphics controller
+      vb.customize ['modifyvm', :id, '--graphicscontroller', 'vboxsvga']
+      # Explicitly disable unnecessary features for better performance
+      vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+      vb.customize ["modifyvm", :id, "--accelerate2dvideo", "off"]
+      vb.customize ['modifyvm', :id, '--clipboard', 'disabled']
+      vb.customize ['modifyvm', :id, '--draganddrop', 'disabled']
+      vb.customize ['modifyvm', :id, '--vrde', 'off']
     end
 
     winw1.vm.network :private_network, ip:"#{windows_node_ip}"
@@ -78,12 +112,13 @@ Vagrant.configure(2) do |config|
     winw1.winrm.password = "vagrant"
 
     if not File.file?(".lock/joined") then
-     # Update containerd
-     puts "calico: #{calico_version}; containerd: #{containerd_version}"
-     winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
+      # Update containerd
+      winw1.vm.provision "shell", path: "sync/windows/0-containerd.ps1", args: "#{calico_version} #{containerd_version}", privileged: true
 
       # Joining the controlplane
       winw1.vm.provision "shell", path: "sync/windows/forked.ps1", args: "#{kubernetes_version}", privileged: true
+      # TODO: Why this is required? From Makefile: making mock kubejoin file to keep Vagrantfile happy in sync/shared
+      FileUtils.touch("sync/shared/kubejoin.ps1") unless File.exist?("sync/shared/kubejoin.ps1")
       winw1.vm.provision "shell", path: "sync/shared/kubejoin.ps1", privileged: true #, run: "never"
     else
       if not File.file?(".lock/cni") then

--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.20
+
+use ./magefiles

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -1,0 +1,27 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/magefile/mage/mg"
+)
+
+// Build Kubernetes from sources for Linux and Windows.
+// This step is optional, an alternative to fetch command.
+func Build() error {
+	mg.SerialDeps(startup, checkVagrant)
+
+	log.Println("TODO: Building Kubernetes from sources on Windows host without make is not implemented yet")
+
+	if Settings["build_from_source"] == "false" {
+		log.Printf("File %s declares 'build_from_source=%v'. Skipping.", os.Getenv("VAGRANT_VARIABLES"), Settings["build_from_source"])
+		return nil
+	}
+
+	logTargetRunTime("Build")
+	return nil
+}

--- a/magefiles/clean.go
+++ b/magefiles/clean.go
@@ -1,0 +1,46 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// Delete cluster and start fresh destroying existing Vagrant machines.
+func Clean() error {
+	mg.SerialDeps(startup, checkVagrant)
+
+	// ignore errors and continue
+	sh.Run("vagrant", "destroy", "--force")
+
+	var volatilePaths = [...]string{
+		filepath.Join("sync", "linux", "bin"),
+		filepath.Join("sync", "windows", "bin"),
+		filepath.Join("sync", "shared", "config"),
+		filepath.Join("sync", "shared", "kubeadm.yaml"),
+		filepath.Join("sync", "shared", "kubejoin.ps1"),
+		filepath.Join("sync", "shared", "variables.yaml"),
+		filepath.Join(".lock"),
+		filepath.Join(".vagrant"),
+	}
+
+	for _, path := range volatilePaths {
+		_, err := os.Stat(filepath.Clean(path))
+		if !os.IsNotExist(err) {
+			log.Println("Cleaning", path)
+			err := os.RemoveAll(path)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	logTargetRunTime("Clean")
+	return nil
+}

--- a/magefiles/fetch.go
+++ b/magefiles/fetch.go
@@ -1,0 +1,125 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+)
+
+// Download Kubernetes binaries for Linux and Windows.
+// Default Kubernetes version is declared in variables.yaml.
+// User can declare custom version in variables.local.yaml,
+// a user-specific copy of variables.yaml.
+func Fetch() error {
+	mg.SerialDeps(startup)
+
+	if Settings["build_from_source"] == "true" {
+		log.Println("TODO: Building Kubernetes from sources on Windows host without make is not implemented yet")
+		log.Printf("File %s declares 'build_from_source=%v'. Skipping.", os.Getenv("VAGRANT_VARIABLES"), Settings["build_from_source"])
+		return nil
+	}
+
+	// Fetch Kubernetes version manifest
+	var kubernetesVersion = Settings["kubernetes_version"]
+	manifestUrl := fmt.Sprintf("https://storage.googleapis.com/k8s-release-dev/ci/latest-%s.txt", kubernetesVersion)
+	log.Println("Downloading manifest", manifestUrl)
+	kubernetesGitVersion, _, _ := downloadKubernetesVersion(manifestUrl)
+	if kubernetesGitVersion == "" {
+		log.Fatalf("Failed to determined Kubernetes tag and hash from version %s", kubernetesGitVersion)
+	}
+
+	log.Printf("Downloading binaries of Kubernetes %s", kubernetesGitVersion)
+
+	// Download Linux binaries
+	binPath := filepath.Join("sync", "linux", "bin")
+	mustCreateDirectory(binPath)
+
+	for _, exe := range []string{"kubeadm", "kubectl", "kubelet"} {
+		downloadPath := filepath.Join(binPath, exe)
+		url := fmt.Sprintf("https://storage.googleapis.com/k8s-release-dev/ci/%s/bin/linux/amd64/%s", kubernetesGitVersion, exe)
+		log.Printf("Downloading %s from %s", downloadPath, url)
+		_, err := os.Stat(downloadPath)
+		if os.IsNotExist(err) {
+			downloadFile(url, downloadPath)
+		} else {
+			log.Println("File exists. Skipping.")
+		}
+	}
+
+	// Download Windows binaries
+	binPath = filepath.Join("sync", "windows", "bin")
+	mustCreateDirectory(binPath)
+
+	for _, exe := range []string{"kubeadm.exe", "kubelet.exe", "kube-proxy.exe"} {
+		downloadPath := filepath.Join(binPath, exe)
+		url := fmt.Sprintf("https://storage.googleapis.com/k8s-release-dev/ci/%s/bin/windows/amd64/%s", kubernetesGitVersion, exe)
+		log.Printf("Downloading %s from %s", downloadPath, url)
+		_, err := os.Stat(downloadPath)
+		if os.IsNotExist(err) {
+			downloadFile(url, downloadPath)
+		} else {
+			log.Println("File exists. Skipping.")
+		}
+	}
+
+	logTargetRunTime("Fetch")
+	return nil
+}
+
+func mustCreateDirectory(path string) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err := os.Mkdir(path, os.ModePerm)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func downloadFile(url string, outputFile string) {
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(outputFile)
+	if err != nil {
+		panic(err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func downloadKubernetesVersion(manifestUrl string) (string, string, string) {
+	resp, err := http.Get(manifestUrl)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	version := string(body)
+	parts := strings.Split(version, "+")
+	tag := strings.TrimSpace(parts[0])
+	sha := strings.TrimSpace(parts[1])
+	return version, tag, sha
+}

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,0 +1,8 @@
+module magefile
+
+go 1.20
+
+require (
+	github.com/magefile/mage v1.14.0
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,0 +1,6 @@
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -1,0 +1,149 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"gopkg.in/yaml.v2"
+)
+
+// Mage default target.
+var Default = All
+
+// Content loaded from variables.yaml or variables.local.yaml
+// or file passed via VAGRANT_VARIABLES environment variable.
+var Settings map[string]string
+
+// Aliases based on original Makefile targets.
+// Use mage -h <target> to see available aliases.
+var Aliases = map[string]interface{}{
+	"1-build-binaries": Build,
+	"2-vagrant-up":     Run,
+	"3-smoke-test":     Test.Smoke,
+	"4-e2e-test":       Test.EndToEnd,
+}
+
+// All logs from Magefiles are prefixed with this tag (e.g. for easy search)
+const LogPrefix = "[swdt-mage] "
+
+// Run complete sequence of targets according to configuration in variables.yaml or variables.local.yaml.
+func All() error {
+	mg.SerialDeps(startup, Fetch, Run, Test.Smoke, Test.EndToEnd)
+
+	logTargetRunTime("All")
+	return nil
+}
+
+// Every public target must depend on startup.
+func startup() error {
+	startTime = time.Now()
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile | log.LUTC | log.Lmsgprefix)
+	log.SetOutput(os.Stdout) // simplify use of tee
+	log.SetPrefix(LogPrefix)
+
+	// User may have already defined VAGRANT_VARIABLES environment variable
+	variablesFile := strings.TrimSpace(os.Getenv("VAGRANT_VARIABLES"))
+	if variablesFile != "" {
+		_, err := os.Stat(variablesFile)
+		if os.IsNotExist(err) {
+			variablesFile = ""
+		}
+	}
+	// Alternatively, user may have created local variables file
+	if variablesFile == "" {
+		_, err := os.Stat("variables.local.yaml")
+		if !os.IsNotExist(err) {
+			variablesFile = "variables.local.yaml"
+		}
+		if variablesFile != "" {
+			log.Printf("Setting environment variable VAGRANT_VARIABLES=%v", variablesFile)
+			os.Setenv("VAGRANT_VARIABLES", variablesFile)
+		}
+	}
+	// Othwerise, fallback to default variable file
+	if variablesFile == "" && strings.TrimSpace(os.Getenv("VAGRANT_VARIABLES")) == "" {
+		_, err := os.Stat("variables.yaml")
+		if os.IsNotExist(err) {
+			return err
+		}
+		variablesFile = "variables.yaml"
+	}
+
+	variablesData, err := ioutil.ReadFile(variablesFile)
+	if err != nil {
+		return err
+	}
+	settings := make(map[string]string)
+	err = yaml.Unmarshal(variablesData, &settings)
+	if err != nil {
+		return err
+	}
+
+	// The internal startup target is a dependency of number of public targets and,
+	// most likely, Mage will never re-run it more than once for bulk of targets e.g. All,
+	// so this check is likely a superfluous check. Still learning Mage though.
+	if len(Settings) == 0 {
+		// Assume variables YAML is always a flat map
+		variables := make([]string, 0, len(settings))
+		for k := range settings {
+			variables = append(variables, k)
+		}
+		sort.Strings(variables)
+
+		log.Println("--- Settings ------------")
+		for _, key := range variables {
+			fmt.Println(key, ": ", settings[key])
+		}
+		log.Println("-------------------------")
+	}
+	Settings = settings
+	return nil
+}
+
+// Every public target that runs vagrant must depend on checkVagrant.
+func checkVagrant() error {
+	_, err := exec.LookPath("vagrant")
+	if err != nil {
+		return err
+	}
+	out, err := sh.Output("vagrant", "--version")
+	if err != nil {
+		return err
+	}
+	log.Println("Using", out)
+	return nil
+}
+
+var startTime time.Time // used to calculate target run time
+
+func logTargetRunTime(target string) {
+	elapsed := time.Since(startTime)
+	log.Printf("Target %s finished in %.2f minutes", target, elapsed.Minutes())
+}
+
+func init() {
+	var err error
+
+	err = os.Setenv("MAGEFILE_ENABLE_COLOR", "1")
+	if err != nil {
+		panic(err)
+	}
+
+	// Always display output from vagrant and other commands,
+	// regardless of mage -v option.
+	os.Setenv("MAGEFILE_VERBOSE", "1")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/magefiles/run.go
+++ b/magefiles/run.go
@@ -1,0 +1,209 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// Create and run Kubernetes cluster with two nodes, Linux and Windows.
+func Run() error {
+	mg.SerialDeps(startup, checkVagrant, checkClusterNotRunning)
+
+	var err error
+
+	log.Println("Creating .lock directory")
+	_, err = os.Stat(".lock")
+	if !os.IsNotExist(err) {
+		err = os.RemoveAll(".lock")
+		if err != nil {
+			return err
+		}
+	}
+	err = os.Mkdir(".lock", os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	// Linux node //////////////////////////////////////////////////////////////
+	log.Println("Creating control plane Linux node")
+	err = sh.Run("vagrant", "up", "controlplane")
+	if err != nil {
+		return err
+	}
+
+	mustSetVagrantPrivateKeyPermissions()
+
+	err = sh.Run("vagrant", "status")
+	if err != nil {
+		return err
+	}
+
+	// Windows node ////////////////////////////////////////////////////////////
+	log.Println("Creating worker Windows node")
+	log.Println("##########################################################")
+	log.Println("Retry vagrant up if the first time the Windows node failed")
+	log.Println("##########################################################")
+
+	const maxAttempts = 10 // TODO: How many to allow? Make configurable via variables.yaml?
+	for i := 1; i < maxAttempts; i++ {
+		log.Printf("vagrant status winw1 - attempt %d of %d", i, maxAttempts)
+		output, err := sh.Output("vagrant", "status", "winw1")
+		if err != nil {
+			return err
+		}
+		status := extractMachineStatus(output, "winw1")
+		log.Println("winw1", status)
+		if strings.Contains(status, "running") {
+			break
+		}
+		log.Printf("vagrant up winw1 - attempt %d of %d", i, maxAttempts)
+		err = sh.Run("vagrant", "up", "winw1")
+		if err != nil {
+			return err
+		}
+	}
+
+	mustSetVagrantPrivateKeyPermissions()
+
+	for i := 1; i < maxAttempts; i++ {
+		log.Printf("kubectl get nodes | grep winw1  - attempt %d of %d", i, maxAttempts)
+		output, err := sh.Output("vagrant", "ssh", "controlplane", "-c", "kubectl get nodes")
+		if err != nil {
+			return err
+		}
+		log.Println(output)
+		if strings.Contains(output, "winw1") {
+			break
+		}
+		log.Printf("vagrant provision winw1 - attempt %d of %d", i, maxAttempts)
+		err = sh.Run("vagrant", "provision", "winw1")
+		if err != nil {
+			return err
+		}
+	}
+
+	// Cluster status //////////////////////////////////////////////////////////
+	joinedFile := filepath.Join(".lock", "joined")
+	log.Printf("Creating %s indicator file for Vagrantfile", joinedFile)
+	mustTouchFile(joinedFile)
+
+	cniFile := filepath.Join(".lock", "cni")
+	log.Printf("Creating %s indicator file for Vagrantfile", cniFile)
+	mustTouchFile(cniFile)
+
+	log.Println("Cluster created")
+	err = sh.Run("vagrant", "status")
+	if err != nil {
+		return err
+	}
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl get nodes")
+	if err != nil {
+		return err
+	}
+
+	logTargetRunTime("Run")
+	return nil
+}
+
+func extractMachineStatus(statusOutput string, machineName string) string {
+	r := fmt.Sprintf(`(?m)^%s.*`, machineName)
+	m := regexp.MustCompile(r)
+	s := m.FindString(statusOutput)
+	v := strings.Split(s, machineName)
+	return strings.TrimSpace(v[1])
+}
+
+func mustTouchFile(filePath string) {
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 644)
+	if err != nil {
+		panic(err)
+	}
+	err = file.Close()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mustSetVagrantPrivateKeyPermissions() {
+	var keyFiles = [...]string{
+		filepath.Join(".vagrant", "machines", "controlplane", "virtualbox", "private_key"),
+		filepath.Join(".vagrant", "machines", "winw1", "virtualbox", "private_key"),
+	}
+
+	for _, keyFile := range keyFiles {
+		_, err := os.Stat(filepath.Clean(keyFile))
+		if os.IsNotExist(err) {
+			continue // key file may not be created yet, skip for now
+		}
+		log.Printf("Setting SSH private key permissions for %s", keyFile)
+		if runtime.GOOS != "windows" {
+			err = os.Chmod(keyFile, 600)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			err = sh.Run("icacls", keyFile, "/c", "/t", "/Inheritance:d")
+			if err != nil {
+				panic(err)
+			}
+			err = sh.Run("icacls", keyFile, "/c", "/t", "/Inheritance:d")
+			if err != nil {
+				panic(err)
+			}
+			user := fmt.Sprintf("%s:F", os.Getenv("USERNAME"))
+			err = sh.Run("icacls", keyFile, "/c", "/t", "/Grant", user)
+			if err != nil {
+				panic(err)
+			}
+			err = sh.Run("icacls", keyFile, "/c", "/t", "/Grant:r", user)
+			if err != nil {
+				panic(err)
+			}
+			err = sh.Run("icacls", keyFile, "/c", "/t", "/Remove:g", "Administrator", "Authenticated Users", "BUILTIN\\Administrators", "BUILTIN", "Everyone", "System", "Users")
+			if err != nil {
+				panic(err)
+			}
+			err = sh.Run("icacls", keyFile)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+// Check if cluster has not already been created.
+// Run clean to delete existing cluster, before recreating it.
+func checkClusterNotRunning() error {
+
+	// TODO: List of required indicators of completed cluster or just check single "joined" file?
+	var indicatorFiles = [...]string{
+		filepath.Join(".lock", "joined"),
+		filepath.Join(".lock", "cni"),
+	}
+
+	var found = []string{}
+
+	for _, path := range indicatorFiles {
+		_, err := os.Stat(filepath.Clean(path))
+		if !os.IsNotExist(err) {
+			found = append(found, path)
+		}
+	}
+
+	if len(found) > 0 {
+		log.Fatalln("Cluster already exists. Run `mage clean` first to delete the existing cluster.")
+	}
+
+	return nil
+}

--- a/magefiles/status.go
+++ b/magefiles/status.go
@@ -1,0 +1,39 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"log"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// Check state of Vagrant machines and Kubernetes nodes.
+func Status() error {
+	mg.SerialDeps(startup, checkVagrant)
+
+	var err error
+
+	log.Println("vagrant status")
+	err = sh.Run("vagrant", "status")
+	if err != nil {
+		return err
+	}
+
+	log.Println("kubectl get nodes")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl get nodes")
+	if err != nil {
+		return err
+	}
+
+	log.Println("kubectl get pods")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl get --all-namespaces pods --output=wide")
+	if err != nil {
+		return err
+	}
+
+	logTargetRunTime("Status")
+	return nil
+}

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -1,0 +1,62 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"log"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+type Test mg.Namespace
+
+// Run smoke tests.
+func (Test) Smoke() error {
+	mg.SerialDeps(startup, checkVagrant)
+
+	var err error
+
+	log.Printf("kubectl apply -f /var/sync/linux/smoke-test.yaml")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl apply -f /var/sync/linux/smoke-test.yaml")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("kubectl scale deployment whoami-windows --replicas 0")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl scale deployment whoami-windows --replicas 0")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("kubectl scale deployment whoami-windows --replicas 3")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl scale deployment whoami-windows --replicas 3")
+	if err != nil {
+		return err
+	}
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl wait --for=condition=Ready=true pod -l 'app=whoami-windows' --timeout=600s")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("kubectl exec -it netshoot -- curl http://whoami-windows:80/")
+	err = sh.Run("vagrant", "ssh", "controlplane", "-c", "kubectl exec -it netshoot -- curl http://whoami-windows:80/")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run end-to-end tests.
+func (Test) EndToEnd() error {
+	mg.SerialDeps(startup, checkVagrant)
+
+	log.Printf("Running ./e2e.sh on controlplane")
+	err := sh.Run("vagrant", "ssh", "controlplane", "-c", "cd /var/sync/linux && chmod +x ./e2e.sh && ./e2e.sh")
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Features

This PR includes two features:

1. These are experimental Vagrant boxes which attempt to address  issues like WinRM not starting, and boot timeouts, OS and VirtualBox guest additions update, and enable/disable VirtualBox features explicitly (for documentation, control, easier troubleshooting). These boxes have proved to be a working solution, and significantly speed up cluster provisioning for testing. Check the boxes repository for details: https://github.com/mloskot/sig-windows-dev-tools-boxes

2. Add Magefiles - https://magefile.org - as functional equivalent to the existing Makefile, but as a portable solution for all platforms supported by Go. Magefiles _remove requirement_ of use of WSL as a proxy providing GNU Make on Windows host, aks  [true windows support](https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/203).

## Tester's Quickstart (with Mage)

_TODO: This guide could be copied into the `README.md` before merge_

> **Warning:** Currently tested on Windows host, but this procedure should (be made to) work on Linux, Mac OS too

1. Install latest VirtualBox 7.0, latest Vagrant, Go 1.20 and latest Mage. See [updated README.md](https://github.com/kubernetes-sigs/sig-windows-dev-tools/pull/264/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
2. Switch your local repo to this PR: `gh pr checkout 264` 
3. Optionally, copy `variables.yaml` to `variables.local.yaml` and modify `variables.local.yaml` as you desire, for example:
    - tweak RAM and CPUs for machines
    - bump Kubernetes to 1.27
    - bump Calico to 3.25.1
    - bump containerd to 1.7.0
4. Launch PowerShell or Command Prompt and run `mage -l` to list all available Mage targets (as check `mage` works for you)
5. Run `mage all | tee m.log ` or just `mage | tee m.log` to download required Kubernetes software, download Vagrant boxes ([1](https://app.vagrantup.com/mloskot/boxes/sig-windows-dev-tools-ubuntu-2204) and [2](https://app.vagrantup.com/mloskot/boxes/sig-windows-dev-tools-windows-2019)), run Vagrant to provision the two-node cluster, run smoke tests (it is known the smoke tests may fail).
6. Run `mage status` in separate console. 
    As soon as Vagrant completes provisioning the two VM-s, open new console and start running `mage status` every couple of minutes to watch the cluster status. The `mage status` is a convenient proxy to execute sequence of
    ```console
    vagrant status
    vagrant ssh controlplane -c 'kubectl get nodes'
    vagrant ssh controlplane -c 'kubectl get -A pods'
    ```

   Alternatively, you can run `vagrant ssh controlplane` and inspect the cluster with `kubectl`.

   Alternatively, you can download kubeconfig form the `controlplane` node to run any Kubernetes client directly from the Windows host:
    ```console
    vagrant plugin install vagrant-scp
    vagrant scp controlplane:~/.kube/config ./swdt-kubeconfig
    kubectl --kubeconfig=./swdt-kubeconfig get nodes
    kubectl --kubeconfig=./swdt-kubeconfig get -A pods
    ...
    ```
8. Report back your results
  
------

My initial run logs https://gist.github.com/mloskot/2670e7e7331f90e390eb5a750de7bf78