### PR TITLE
Add mage targets to create/destroy/start/stop individual nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ This is a fully batteries-included development environment for Windows on Kubern
 - Windows binaries for kube-proxy.exe and kubelet.exe that are fully built from source (K8s main branch)
 - Kubeadm installation that can put the bleeding-edge Linux control plane in place, so you can test new features like privileged containers
 
-## Quick Start
-
-### Prerequisites
+## Prerequisites
 
 - Linux host - mostly tested on [Ubuntu](#ubuntu). Alternatively, Windows host.
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (we only have VirtualBox automated here, but these recipes have been used with others, like Microsoft HyperV and VMware Fusion).
@@ -27,7 +25,7 @@ This is a fully batteries-included development environment for Windows on Kubern
 
 Go and Mage are required to run steps of the cluster workflow which are coded as [Magefiles](https://magefile.org) in Go language.
 
-### Getting cluster up and running
+## Quick Start
 
 Simple steps to a Windows Kubernetes cluster, from scratch, from Kubernetes binaries downloaded or built from source:
 
@@ -97,6 +95,38 @@ Simple steps to a Windows Kubernetes cluster, from scratch, from Kubernetes bina
 6. Run `mage test:smoke` and `mage test:endToEnd`.
 
 7. Run `mage clean` to delete the whole cluster and start over.
+
+## Advanced Usage
+
+There is a set of `mage` targets dedicated to testers who may appareciate fine-grained control of nodes lifetime:
+
+1. Create individual node
+
+    ```console
+    mage node:create controlplane
+    mage node:create winw1
+    ```
+
+2. Stop individual node
+
+    ```console
+    mage node:stop controlplane
+    mage node:stop winw1
+    ```
+
+3. Start individual node
+
+    ```console
+    mage node:start controlplane
+    mage node:start winw1
+    ```
+
+4. Destroy individual node
+
+    ```console
+    mage node:destroy winw1
+    mage node:destroy controlplane
+    ```
 
 ## Windows with WSL
 

--- a/magefiles/node.go
+++ b/magefiles/node.go
@@ -1,0 +1,121 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// Exported targets namespace
+type Node mg.Namespace
+
+// Destroy Vagrant machine with given cluster node name.
+func (Node) Create(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		log.Fatalln("Node name is empty")
+	}
+
+	mg.SerialDeps(startup, checkClusterNotExist, Config.Settings, Config.Vagrant)
+
+	// Validate the node is known to Vagrant
+	_, err := sh.Output("vagrant", "status", nodeName)
+	if err != nil {
+		return err
+	}
+
+	if nodeName == "controlplane" {
+		mg.SerialDeps(runLinuxControlPlaneNode)
+		return nil
+	}
+
+	if nodeName == "winw1" {
+		mg.SerialDeps(runWindowsWorkerNode)
+		return nil
+	}
+
+	return fmt.Errorf("Node '%s' is unknown", nodeName)
+}
+
+// Destroy Vagrant machine with given cluster node.
+func (Node) Destroy(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		log.Fatalln("Node name is empty")
+	}
+
+	mg.SerialDeps(Config.Vagrant)
+
+	var err error
+
+	// Validate the node is known to Vagrant
+	_, err = sh.Output("vagrant", "status", nodeName)
+	if err != nil {
+		return err
+	}
+
+	err = sh.Run("vagrant", "destroy", "--force", nodeName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start existing Vagrant machine name with given cluster node name, without running provisioners.
+func (Node) Start(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		log.Fatalln("Node name is empty")
+	}
+
+	mg.SerialDeps(Config.Vagrant)
+
+	var err error
+
+	// Validate the node is known to Vagrant
+	_, err = sh.Output("vagrant", "status", nodeName)
+	if err != nil {
+		return err
+	}
+
+	err = sh.Run("vagrant", "up", "--no-provision", nodeName)
+	if err != nil {
+		return err
+	}
+
+	logTargetRunTime("Clean")
+	return nil
+}
+
+// Stop existing Vagrant machine name with given cluster node name
+func (Node) Stop(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		log.Fatalln("Node name is empty")
+	}
+
+	mg.SerialDeps(Config.Vagrant)
+
+	var err error
+
+	// Validate the node is known to Vagrant
+	_, err = sh.Output("vagrant", "status", nodeName)
+	if err != nil {
+		return err
+	}
+
+	err = sh.Run("vagrant", "halt", nodeName)
+	if err != nil {
+		return err
+	}
+
+	logTargetRunTime("Clean")
+	return nil
+}


### PR DESCRIPTION
From my own experience, testers may appreciate ability to test creating and running control plane node and worker node individually. So, here are extra `mage` targets (see `README.md`).

/cc @jayunit100 @aravindhp 