### PR TITLE
version bumps and config for calico host process container

### DIFF
--- a/sync/linux/calico-0.sh
+++ b/sync/linux/calico-0.sh
@@ -40,6 +40,15 @@ k8s_service_host=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.su
 k8s_service_port=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].ports[0].port}')
 sed -i "s|KUBERNETES_SERVICE_HOST: \"\"|KUBERNETES_SERVICE_HOST: \"$k8s_service_host\"|g" calico-windows.yaml
 sed -i "s|KUBERNETES_SERVICE_PORT: \"\"|KUBERNETES_SERVICE_PORT: \"$k8s_service_port\"|g" calico-windows.yaml
+# TODO - (damei) find a better way to update the configmap
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  KUBE_NETWORK: \"Calico.*\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  VXLAN_VNI: \"4096\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  VXLAN_MAC_PREFIX: \"0E-2A\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  CALICO_DATASTORE_TYPE: \"kubernetes\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  FELIX_LOGSEVERITYSCREEN: \"debug\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  CALICO_K8S_NODE_REF: \"winw1\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  CNI_IPAM_TYPE: \"calico-ipam\"|g" calico-windows.yaml
+sed -i "s|FELIX_HEALTHENABLED: \"true\"|FELIX_HEALTHENABLED: \"true\"\n  KUBECONFIG: \"C:/etc/kubernetes/kubelet.conf\"|g" calico-windows.yaml
 kubectl create -f calico-windows.yaml
 
 curl -L https://github.com/projectcalico/calico/releases/download/v${calico_version}/calicoctl-linux-amd64 -o calicoctl

--- a/sync/linux/smoke-test.yaml
+++ b/sync/linux/smoke-test.yaml
@@ -23,7 +23,7 @@ spec:
         value: Windows
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.23.4
         securityContext:
           privileged: true
       nodeSelector:

--- a/variables.yaml
+++ b/variables.yaml
@@ -8,8 +8,8 @@ build_from_source: "false"
 pod_cidr: "100.244.0.0/16"
 
 # containerd version
-containerd_version: "1.6.15"
-calico_version: "3.25.0"
+containerd_version: "1.7.0"
+calico_version: "3.25.1"
 
 ## Linux settings
 k8s_linux_kubelet_nodeip: "10.20.30.10"


### PR DESCRIPTION
HPCs are more compatible with containerd 1.7+, and calico as a host process requires additional environment variables which were missing. 

Partially Fixes https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/269.

This PR gets rid of the warnings/error mentioned in https://github.com/kubernetes-sigs/sig-windows-dev-tools/issues/269 however inter-pod (cross-platform) networking is still not working.