### PR TITLE
refactor: Rename winw1 node to winworker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ official Kubernetes binaries or binaries built from source:
     By default, cluster is created from Kubernetes pre-built binaries.
     To compile Kubernetes from local source, on Linux host, see instructions later in this doc.
 
-    > **TIP:** If provisioning of `winw1` failed, then try running `vagrant provision winw1`, just in case you have a flake during Windows installation.
+    > **TIP:** If provisioning of `winworker` failed, then try running `vagrant provision winworker`, just in case you have a flake during Windows installation.
 
 4. Check status of machines, nodes and pods
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -95,7 +95,7 @@ As we are utilizing our existing Windows 11 computer, we will start by shrinking
 
     - Windows node:
     ```
-    vagrant ssh winw1
+    vagrant ssh winworker
     ```
 
 Now [let's run it!](https://github.com/kubernetes-sigs/sig-windows-dev-tools#lets-run-it)

--- a/docs/other.md
+++ b/docs/other.md
@@ -19,11 +19,11 @@ The Windows node might stay 'NotReady' for a while, because it takes some time t
 vagrant@controlplane:~$ kubectl get nodes
 NAME     STATUS     ROLES                  AGE    VERSION
 controlplane    Ready      control-plane,controlplane   8m4s   v1.20.4
-winw1           NotReady   <none>                       64s    v1.20.4
+winworker       NotReady   <none>                       64s    v1.20.4
 ```
 ...
 ```
 NAME     STATUS   ROLES                  AGE     VERSION
 controlplane    Ready    control-plane,controlplane     16m     v1.20.4
-winw1           Ready    <none>                         9m11s   v1.20.4
+winworker       Ready    <none>                         9m11s   v1.20.4
 ```

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -53,5 +53,5 @@ kubectl get pods -A
 
 - Windows node:
 ```
-vagrant ssh winw1
+vagrant ssh winworker
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,26 +70,26 @@ control of nodes lifetime:
 
     ```console
     mage node:create controlplane
-    mage node:create winw1
+    mage node:create winworker
     ```
 
 2. Stop individual node
 
     ```console
     mage node:stop controlplane
-    mage node:stop winw1
+    mage node:stop winworker
     ```
 
 3. Start individual node
 
     ```console
     mage node:start controlplane
-    mage node:start winw1
+    mage node:start winworker
     ```
 
 4. Destroy individual node
 
     ```console
-    mage node:destroy winw1
+    mage node:destroy winworker
     mage node:destroy controlplane
     ```

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -5,7 +5,7 @@
 You'll obviously want to run commands on the Windows box. The easiest way is to SSH into the Windows machine and use powershell from there:
 
 ```
-vagrant ssh winw1
+vagrant ssh winworker
 C:\ > powershell
 ```
 
@@ -13,7 +13,7 @@ Optionally, you can do this by noting the IP address during `vagrant provision` 
 To run a *command* on the Windows boxes without actually using the UI, you can use `winrm`, which is integrated into Vagrant. For example, you can run:
 
 ```
-vagrant winrm winw1 --shell=powershell --command="ls"
+vagrant winrm winworker --shell=powershell --command="ls"
 ```
 
 IF you want to debug on the windows node, you can also run crictl:

--- a/experiments/image-builder/README.md
+++ b/experiments/image-builder/README.md
@@ -36,7 +36,7 @@ It's still required to join the control plane, and this step is required
 via Kubejoin, with a provision, this is an usage example:
 
 ```
-winw1.vm.provision "shell", path: "sync/shared/kubejoin.ps1", privileged: true
+winworker.vm.provision "shell", path: "sync/shared/kubejoin.ps1", privileged: true
 ```
 
 ## How image-builder creates the image

--- a/magefiles/cluster.go
+++ b/magefiles/cluster.go
@@ -114,18 +114,18 @@ func runWindowsWorkerNode() error {
 	log.Println("Creating Windows worker node")
 
 	for i := 0; i < settings.Vagrant.WindowsMaxAttempts; i++ {
-		log.Printf("vagrant status winw1 - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
-		output, err := sh.Output("vagrant", "status", "winw1")
+		log.Printf("vagrant status winworker - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
+		output, err := sh.Output("vagrant", "status", "winworker")
 		if err != nil {
 			return err
 		}
-		status := extractMachineStatus(output, "winw1")
-		log.Println("winw1", status)
+		status := extractMachineStatus(output, "winworker")
+		log.Println("winworker", status)
 		if strings.Contains(status, "running") {
 			break
 		}
-		log.Printf("vagrant up winw1 - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
-		err = sh.Run("vagrant", "up", "winw1")
+		log.Printf("vagrant up winworker - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
+		err = sh.Run("vagrant", "up", "winworker")
 		if err != nil {
 			return err
 		}
@@ -139,17 +139,17 @@ func runWindowsWorkerNode() error {
 	// TODO: Is re-provisioning required? What problem does it actually solve? If boxes are usable then vagrant up above should be sufficient.
 	log.Println("Provisioning Windows worker node")
 	for i := 0; i < settings.Vagrant.WindowsMaxAttempts; i++ {
-		log.Printf("kubectl get nodes | grep winw1  - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
+		log.Printf("kubectl get nodes | grep winworker  - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
 		output, err := sh.Output("vagrant", "ssh", "controlplane", "-c", "kubectl get nodes")
 		if err != nil {
 			return err
 		}
 		log.Println(output)
-		if strings.Contains(output, "winw1") {
+		if strings.Contains(output, "winworker") {
 			break
 		}
-		log.Printf("vagrant provision winw1 - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
-		err = sh.Run("vagrant", "provision", "winw1")
+		log.Printf("vagrant provision winworker - attempt %d of %d", i+1, settings.Vagrant.WindowsMaxAttempts)
+		err = sh.Run("vagrant", "provision", "winworker")
 		if err != nil {
 			return err
 		}
@@ -237,7 +237,7 @@ func setVagrantPrivateKeyPermissions() error {
 	// e.g. in case machines are renamed.
 	var keyFiles = [...]string{
 		filepath.Join(".vagrant", "machines", "controlplane", "virtualbox", "private_key"),
-		filepath.Join(".vagrant", "machines", "winw1", "virtualbox", "private_key"),
+		filepath.Join(".vagrant", "machines", "winworker", "virtualbox", "private_key"),
 	}
 
 	for _, keyFile := range keyFiles {

--- a/magefiles/node.go
+++ b/magefiles/node.go
@@ -35,7 +35,7 @@ func (Node) Create(nodeName string) error {
 		return nil
 	}
 
-	if nodeName == "winw1" {
+	if nodeName == "winworker" {
 		mg.SerialDeps(runWindowsWorkerNode)
 		return nil
 	}

--- a/sync/linux/controlplane.sh
+++ b/sync/linux/controlplane.sh
@@ -213,7 +213,7 @@ metadata:
   namespace: kube-system
 subjects:
 - kind: User
-  name: system:node:winw1
+  name: system:node:winworker
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The two-node hybrid cluster is made of `controlplane` and `winworker` now.

Initially, I wanted to name it `workwinner` but it hasn't deserved it yet...

p.s. VirtualBox is not making my Saturday, but a day without commit
feels like no progress, so allowing myself a bit of bikeshedding ;P

