### PR TITLE
fix(cli): Execute PowerShell command via SSH as oneliner

### DIFF
--- a/experiments/swdt/pkg/pwsh/setup/setup.go
+++ b/experiments/swdt/pkg/pwsh/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+
 	"github.com/fatih/color"
 	"k8s.io/klog/v2"
 )
@@ -20,7 +21,7 @@ type Runner struct {
 }
 
 func (r *Runner) InstallChoco() error {
-	klog.Info(mainc.Sprint("Installing Choco with PowerShell."))
+	klog.Info(mainc.Sprint("Installing Choco with PowerShell"))
 
 	if r.ChocoExists() {
 		klog.Info(resc.Sprintf("Choco already exists, skipping installation..."))


### PR DESCRIPTION
Apparently, ssh.Session trips over newline characters
while executing the multiline command on the remote
Windows host with PowerShell. Only command in first
line is executed.

Replacing newline character with `;` as no-op.

----

Running the swdt-cli in PowerShell 7 on Windows host:

- Before the fix

![image](https://github.com/kubernetes-sigs/sig-windows-dev-tools/assets/80741/b53c0190-3c06-417c-b439-05748f10110e)

- After the fix

![image](https://github.com/kubernetes-sigs/sig-windows-dev-tools/assets/80741/f037af96-a139-42ec-bead-f8ff9c541213)
