### PR TITLE
fix(cli): session.Run is sensitive to quoting on Windows host

### DIFF
--- a/experiments/swdt/pkg/connections/ssh.go
+++ b/experiments/swdt/pkg/connections/ssh.go
@@ -110,7 +110,9 @@ func (c *SSHConnection) Run(args string) (string, error) {
 
 	// Multiline PowerShell commands over SSH trip over newlines - only first one is executed
 	args = regexp.MustCompile(`\r?\n`).ReplaceAllLiteralString(args, ";")
-	if err := session.Run("powershell -nologo -noprofile -c " + args); err != nil {
+	cmd := fmt.Sprintf("powershell -nologo -noprofile -c { %s }", args)
+	// TODO(mloskot): Log executed commands in --verbose mode
+	if err := session.Run(cmd); err != nil {
 		return "", err
 	}
 

--- a/experiments/swdt/pkg/pwsh/setup/setup.go
+++ b/experiments/swdt/pkg/pwsh/setup/setup.go
@@ -81,11 +81,12 @@ func (r *SetupRunner) EnableRDP(enable bool) error {
 		return nil
 	}
 
-	output, err := r.run(`Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -name "fDenyTSConnections" -value 0;
+	klog.Info(resc.Sprintf("Enabling RDP."))
+	output, err := r.run(`Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Terminal Server" -name "fDenyTSConnections" -value 0;
 		Enable-NetFirewallRule -DisplayGroup "Remote Desktop"`)
 	if err != nil {
 		return err
 	}
-	klog.Info(resc.Sprintf("Enabling RDP. %s", output))
+	klog.Info(resc.Sprintf(output))
 	return nil
 }


### PR DESCRIPTION
There is a strange issue with SSH executor via session.Run
on Windows host (i.e. Windows SSH client) which seems to be
prone to failure depending on particular arrangements of quote,
double-quotes, etc. in PowerShell command.

For example, this fails

```
output, err := r.run(`Enable-NetFirewallRule -DisplayGroup "Remote Desktop"`)
```

while this succeeds

```go
output, err := r.run(`Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'`)
```

Wrapping the command with `{` and `}` also seems to solve this problem, effectively `session.Run` executing this with success

```powershell;
powershell -nologo -noprofile -c { Enable-NetFirewallRule -DisplayGroup "Remote Desktop" }
```

Interestingly, this issue seems not reproducible Linux host.
