### PR TITLE
fix(cli): choco executable is not in PATH

### DIFF
--- a/experiments/swdt/pkg/pwsh/setup/setup.go
+++ b/experiments/swdt/pkg/pwsh/setup/setup.go
@@ -14,7 +14,7 @@ var (
 
 const (
 	CHOCO_PATH    = "C:\\ProgramData\\chocolatey\\bin\\choco.exe"
-	CHOCO_INSTALL = "choco install --accept-licenses --yes"
+	CHOCO_INSTALL = "install --accept-licenses --yes"
 )
 
 type SetupRunner struct {
@@ -58,7 +58,7 @@ func (r *SetupRunner) InstallChocoPackages(packages []string) error {
 
 	klog.Info(mainc.Sprint("Installing Choco packages."))
 	for _, pkg := range packages {
-		output, err := r.run(fmt.Sprintf("%s %s", CHOCO_INSTALL, pkg))
+		output, err := r.run(fmt.Sprintf("%s %s %s", CHOCO_PATH, CHOCO_INSTALL, pkg))
 		if err != nil {
 			return err
 		}

--- a/experiments/swdt/pkg/pwsh/setup/setup_test.go
+++ b/experiments/swdt/pkg/pwsh/setup/setup_test.go
@@ -40,7 +40,7 @@ func TestInstallChocoPackages(t *testing.T) {
 	assert.Len(t, calls, expectedCalls)
 	assert.Equal(t, calls[0], chocoCheck)
 	for i := 0; i < expectedCalls-1; i++ {
-		assert.Equal(t, calls[i+1], fmt.Sprintf("%s %s", CHOCO_INSTALL, pkgs[i]))
+		assert.Equal(t, calls[i+1], fmt.Sprintf("%s %s %s", CHOCO_PATH, CHOCO_INSTALL, pkgs[i]))
 	}
 }
 


### PR DESCRIPTION
choco needs to be executed via absolute path
to the executable.
