### PR TITLE
feat(cli): Add support for klog levels

### DIFF
--- a/experiments/swdt/cmd/kubernetes.go
+++ b/experiments/swdt/cmd/kubernetes.go
@@ -17,10 +17,11 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"swdt/apis/config/v1alpha1"
 	"swdt/pkg/pwsh/executor"
 	"swdt/pkg/pwsh/kubernetes"
+
+	"github.com/spf13/cobra"
 )
 
 func init() {

--- a/experiments/swdt/cmd/root.go
+++ b/experiments/swdt/cmd/root.go
@@ -17,14 +17,18 @@ limitations under the License.
 package cmd
 
 import (
+	"flag"
 	"os"
 	"swdt/apis/config/v1alpha1"
 	"swdt/pkg/config"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 )
 
 func init() {
+	klog.InitFlags(nil)
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	rootCmd.PersistentFlags().StringP("config", "c", "samples/config.yaml", "Configuration file path.")
 }
 

--- a/experiments/swdt/pkg/config/node.go
+++ b/experiments/swdt/pkg/config/node.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
 )
 
 var (
@@ -38,6 +39,7 @@ func init() {
 
 // LoadConfigNodeFromFile LoadConfigFromFile returns the marshalled Node configuration object
 func LoadConfigNodeFromFile(file string) (*v1alpha1.Node, error) {
+	klog.V(1).Infof("Loading Node configuration from %s", file)
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It would be helpful if klog dumps commands executed on remote node or details of dialled connection.

